### PR TITLE
feat: complete Sprint 6 export format and crop settings API

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.clip_insights import (
     ClipSearchResponse,
     PodcastClipMetrics,
 )
+from app.models.export_settings import ExportSettings, ExportSettingsInput
 from app.models.media import MediaInspectionResult
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.publishing import (
@@ -46,6 +47,8 @@ __all__ = [
     "ClipSearchHit",
     "ClipSearchResult",
     "ClipSearchResponse",
+    "ExportSettings",
+    "ExportSettingsInput",
     "GenerateClipsRequest",
     "MediaInspectionResult",
     "OverlayDecision",

--- a/backend/app/models/clipping.py
+++ b/backend/app/models/clipping.py
@@ -6,6 +6,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.analysis import ScoreSegment
+from app.models.export_settings import ExportSettings, ExportSettingsInput
 from app.models.overlay import OverlayDecision
 from app.models.transcription import TranscriptionResult
 
@@ -26,6 +27,7 @@ class ClipResult(BaseModel):
     download_url: str | None = None
     published_at: datetime | None = None
     overlay: OverlayDecision | None = None
+    export_settings: ExportSettings = Field(default_factory=ExportSettings)
 
     @field_validator("id", "video_url", "subtitle_text")
     @classmethod
@@ -44,6 +46,7 @@ class ClipGenerationResult(BaseModel):
     clips: list[ClipResult] = Field(default_factory=list)
     processing_time_seconds: float = Field(ge=0)
     download_folder_url: str
+    export_settings: ExportSettings = Field(default_factory=ExportSettings)
 
     @field_validator("podcast_id", "download_folder_url")
     @classmethod
@@ -59,4 +62,5 @@ class GenerateClipsRequest(BaseModel):
 
     score_segments: list[ScoreSegment] | None = None
     transcription: TranscriptionResult | None = None
+    export_settings: ExportSettingsInput | None = None
 

--- a/backend/app/models/export_settings.py
+++ b/backend/app/models/export_settings.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+ExportMode = Literal["landscape", "portrait"]
+CropMode = Literal["none", "center_crop", "smart_crop"]
+
+
+class ExportSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    export_mode: ExportMode = "landscape"
+    crop_mode: CropMode = "none"
+    mobile_optimized: bool = False
+    face_tracking_enabled: bool = False
+
+    @model_validator(mode="after")
+    def validate_export_preferences(self) -> "ExportSettings":
+        if self.export_mode == "landscape" and self.crop_mode != "none":
+            raise ValueError("Landscape exports only support crop_mode='none'.")
+        if self.face_tracking_enabled and self.crop_mode != "smart_crop":
+            raise ValueError("Face tracking requires crop_mode='smart_crop'.")
+        return self
+
+
+class ExportSettingsInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    export_mode: ExportMode = "landscape"
+    crop_mode: CropMode | None = None
+    mobile_optimized: bool = False
+    face_tracking_enabled: bool = False
+
+    @model_validator(mode="after")
+    def validate_request_preferences(self) -> "ExportSettingsInput":
+        resolved_crop_mode = self.crop_mode or ("center_crop" if self.export_mode == "portrait" else "none")
+        if self.export_mode == "landscape" and resolved_crop_mode != "none":
+            raise ValueError("Landscape exports only support crop_mode='none'.")
+        if self.face_tracking_enabled and resolved_crop_mode != "smart_crop":
+            raise ValueError("Face tracking requires crop_mode='smart_crop'.")
+        return self
+
+    def resolve(self) -> ExportSettings:
+        return ExportSettings(
+            export_mode=self.export_mode,
+            crop_mode=self.crop_mode or ("center_crop" if self.export_mode == "portrait" else "none"),
+            mobile_optimized=self.mobile_optimized,
+            face_tracking_enabled=self.face_tracking_enabled,
+        )

--- a/backend/app/models/podcast.py
+++ b/backend/app/models/podcast.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.models.export_settings import ExportSettings
+
 
 class PodcastRecord(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -12,6 +14,7 @@ class PodcastRecord(BaseModel):
     duration: int
     status: str
     storage_path: str | None = None
+    export_settings: ExportSettings | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -23,6 +26,7 @@ class PodcastResponse(BaseModel):
     duration: int
     status: str
     storage_path: str | None = None
+    export_settings: ExportSettings | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -160,7 +160,13 @@ async def generate_podcast_clips(
                 ),
             )
 
-        clips = await asyncio.to_thread(generate_clips, podcast_id, score_segments, transcription)
+        clips = await asyncio.to_thread(
+            generate_clips,
+            podcast_id,
+            score_segments,
+            transcription,
+            payload.export_settings,
+        )
     except (AnalysisError, ClippingError) as exc:
         update_podcast_status_for_user(podcast_id, current_user.id, "ready_for_processing")
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
@@ -170,6 +176,7 @@ async def generate_podcast_clips(
         podcast_id,
         clips,
         processing_time_seconds=round(time.perf_counter() - started_at, 3),
+        export_settings=clips[0].export_settings if clips else None,
     )
 
 

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -11,6 +11,7 @@ from app.config import BACKEND_DIR, ROOT_DIR
 from app.database import UnconfiguredSupabaseClient, service_supabase
 from app.models.analysis import ScoreSegment
 from app.models.clipping import ClipGenerationResult, ClipResult
+from app.models.export_settings import ExportSettings, ExportSettingsInput
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.transcription import TranscriptWord, TranscriptionResult
 import app.services.overlay_mapping_service as overlay_mapping_service_module
@@ -150,6 +151,7 @@ def generate_clips(
     podcast_id: str,
     score_segments: list[ScoreSegment],
     transcription: TranscriptionResult,
+    export_settings: ExportSettingsInput | ExportSettings | None = None,
 ) -> list[ClipResult]:
     podcast_row = _get_podcast_row(podcast_id)
     source_path = _resolve_source_media_path(podcast_row)
@@ -157,6 +159,7 @@ def generate_clips(
     if not selected_segments:
         raise ClippingError("No scored segments are available for clip generation.", status_code=404)
 
+    resolved_export_settings = _resolve_export_settings(export_settings, podcast_row=podcast_row)
     output_dir = _prepare_output_directory(podcast_id)
     overlay_mapping_service_module.service_supabase = service_supabase
     generated_results: list[ClipResult] = []
@@ -191,6 +194,7 @@ def generate_clips(
                 video_url=_build_backend_download_path(clip_id),
                 subtitle_text=subtitle_text,
                 status="ready",
+                export_settings=resolved_export_settings,
             )
             overlay_decision = overlay_mapping_service_module.detect_overlay_decision(
                 podcast_id,
@@ -236,6 +240,10 @@ def generate_clips(
                     "subtitle_url": subtitle_url or str(subtitle_path),
                     "subtitle_text": subtitle_text,
                     "status": "ready",
+                    "export_mode": resolved_export_settings.export_mode,
+                    "crop_mode": resolved_export_settings.crop_mode,
+                    "mobile_optimized": resolved_export_settings.mobile_optimized,
+                    "face_tracking_enabled": resolved_export_settings.face_tracking_enabled,
                 }
             )
         except ClippingError:
@@ -245,6 +253,7 @@ def generate_clips(
         raise ClippingError("No clips could be generated from the selected segments.")
 
     _persist_generated_clips(podcast_id, rows_to_persist)
+    _persist_podcast_export_settings(podcast_id, resolved_export_settings)
     overlay_result = OverlayMappingResult(
         podcast_id=podcast_id,
         total_segments_checked=len(overlay_decisions),
@@ -259,13 +268,16 @@ def build_clip_generation_result(
     clips: list[ClipResult],
     *,
     processing_time_seconds: float,
+    export_settings: ExportSettings | None = None,
 ) -> ClipGenerationResult:
+    resolved_export_settings = export_settings or (clips[0].export_settings if clips else ExportSettings())
     return ClipGenerationResult(
         podcast_id=podcast_id,
         total_clips_generated=len(clips),
         clips=clips,
         processing_time_seconds=round(processing_time_seconds, 3),
         download_folder_url=f"/podcasts/{podcast_id}/clips",
+        export_settings=resolved_export_settings,
     )
 
 
@@ -276,7 +288,7 @@ def get_clips_for_podcast(podcast_id: str) -> ClipGenerationResult | None:
     response = (
         service_supabase.table("clips")
         .select(
-            "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at"
+            "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,export_mode,crop_mode,mobile_optimized,face_tracking_enabled"
         )
         .eq("podcast_id", podcast_id)
         .order("clip_number")
@@ -304,10 +316,16 @@ def get_clips_for_podcast(podcast_id: str) -> ClipGenerationResult | None:
             download_url=str(row.get("download_url") or "").strip() or None,
             published_at=row.get("published_at"),
             overlay=overlays_by_clip_id.get(str(row["id"])),
+            export_settings=_build_export_settings_from_row(row),
         )
         for row in rows
     ]
-    return build_clip_generation_result(podcast_id, clips, processing_time_seconds=0.0)
+    return build_clip_generation_result(
+        podcast_id,
+        clips,
+        processing_time_seconds=0.0,
+        export_settings=clips[0].export_settings if clips else ExportSettings(),
+    )
 
 
 def get_clip_download_target(clip_id: str) -> tuple[str | None, Path | None]:
@@ -682,7 +700,7 @@ def _get_podcast_row(podcast_id: str) -> dict[str, Any]:
 
     response = (
         service_supabase.table("podcasts")
-        .select("id,storage_path")
+        .select("id,storage_path,export_mode,crop_mode,mobile_optimized,face_tracking_enabled")
         .eq("id", podcast_id)
         .limit(1)
         .execute()
@@ -765,6 +783,44 @@ def _persist_generated_clips(podcast_id: str, rows: list[dict[str, Any]]) -> Non
     service_supabase.table("clips").delete().eq("podcast_id", podcast_id).execute()
     if rows:
         service_supabase.table("clips").insert(rows).execute()
+
+
+def _resolve_export_settings(
+    export_settings: ExportSettingsInput | ExportSettings | None,
+    *,
+    podcast_row: dict[str, Any] | None = None,
+) -> ExportSettings:
+    if isinstance(export_settings, ExportSettings):
+        return export_settings
+    if isinstance(export_settings, ExportSettingsInput):
+        return export_settings.resolve()
+    if podcast_row is not None:
+        return _build_export_settings_from_row(podcast_row)
+    return ExportSettings()
+
+
+def _build_export_settings_from_row(row: dict[str, Any]) -> ExportSettings:
+    export_mode = str(row.get("export_mode") or "landscape").strip() or "landscape"
+    crop_mode = str(row.get("crop_mode") or ("center_crop" if export_mode == "portrait" else "none")).strip()
+    return ExportSettings(
+        export_mode=export_mode,  # type: ignore[arg-type]
+        crop_mode=crop_mode,  # type: ignore[arg-type]
+        mobile_optimized=bool(row.get("mobile_optimized") or False),
+        face_tracking_enabled=bool(row.get("face_tracking_enabled") or False),
+    )
+
+
+def _persist_podcast_export_settings(podcast_id: str, export_settings: ExportSettings) -> None:
+    if isinstance(service_supabase, UnconfiguredSupabaseClient):
+        return
+    service_supabase.table("podcasts").update(
+        {
+            "export_mode": export_settings.export_mode,
+            "crop_mode": export_settings.crop_mode,
+            "mobile_optimized": export_settings.mobile_optimized,
+            "face_tracking_enabled": export_settings.face_tracking_enabled,
+        }
+    ).eq("id", podcast_id).execute()
 
 
 def _build_backend_download_path(clip_id: str) -> str:

--- a/backend/app/services/podcast_service.py
+++ b/backend/app/services/podcast_service.py
@@ -1,9 +1,13 @@
 from datetime import UTC, datetime
 
 from app.database import UnconfiguredSupabaseClient, service_supabase
+from app.models.export_settings import ExportSettings
 from app.models.podcast import PodcastRecord, PodcastResponse
 
-PODCAST_COLUMNS = "id,user_id,title,duration,status,storage_path,created_at,updated_at"
+PODCAST_COLUMNS = (
+    "id,user_id,title,duration,status,storage_path,export_mode,crop_mode,"
+    "mobile_optimized,face_tracking_enabled,created_at,updated_at"
+)
 
 
 def _mock_podcasts(user_id: str) -> list[PodcastRecord]:
@@ -20,11 +24,31 @@ def _mock_podcasts(user_id: str) -> list[PodcastRecord]:
             title=title,
             duration=duration,
             status=status,
+            export_settings=ExportSettings(),
             created_at=now,
             updated_at=now,
         )
         for index, (title, duration, status) in enumerate(items, start=1)
     ]
+
+
+def _build_export_settings(row: dict[str, object]) -> ExportSettings:
+    export_mode = str(row.get("export_mode") or "landscape").strip() or "landscape"
+    crop_mode = str(row.get("crop_mode") or ("center_crop" if export_mode == "portrait" else "none")).strip()
+    mobile_optimized = bool(row.get("mobile_optimized") or False)
+    face_tracking_enabled = bool(row.get("face_tracking_enabled") or False)
+    return ExportSettings(
+        export_mode=export_mode,  # type: ignore[arg-type]
+        crop_mode=crop_mode,  # type: ignore[arg-type]
+        mobile_optimized=mobile_optimized,
+        face_tracking_enabled=face_tracking_enabled,
+    )
+
+
+def _serialize_podcast_row(row: dict[str, object]) -> dict[str, object]:
+    payload = dict(row)
+    payload["export_settings"] = _build_export_settings(payload)
+    return payload
 
 
 def get_podcasts_for_user(user_id: str) -> tuple[list[PodcastResponse], bool]:
@@ -39,7 +63,7 @@ def get_podcasts_for_user(user_id: str) -> tuple[list[PodcastResponse], bool]:
         .execute()
     )
     rows = response.data or []
-    return [PodcastResponse.model_validate(item) for item in rows], False
+    return [PodcastResponse.model_validate(_serialize_podcast_row(item)) for item in rows], False
 
 
 def get_podcast_for_user(podcast_id: str, user_id: str) -> PodcastRecord | None:
@@ -55,7 +79,7 @@ def get_podcast_for_user(podcast_id: str, user_id: str) -> PodcastRecord | None:
         .execute()
     )
     rows = response.data or []
-    return PodcastRecord.model_validate(rows[0]) if rows else None
+    return PodcastRecord.model_validate(_serialize_podcast_row(rows[0])) if rows else None
 
 
 def update_podcast_status_for_user(podcast_id: str, user_id: str, status: str) -> PodcastRecord | None:

--- a/backend/sql/export_settings_schema.sql
+++ b/backend/sql/export_settings_schema.sql
@@ -1,0 +1,35 @@
+alter table public.podcasts
+  add column if not exists export_mode text not null default 'landscape',
+  add column if not exists crop_mode text not null default 'none',
+  add column if not exists mobile_optimized boolean not null default false,
+  add column if not exists face_tracking_enabled boolean not null default false;
+
+alter table public.podcasts
+  drop constraint if exists podcasts_export_mode_check;
+
+alter table public.podcasts
+  add constraint podcasts_export_mode_check check (export_mode in ('landscape', 'portrait'));
+
+alter table public.podcasts
+  drop constraint if exists podcasts_crop_mode_check;
+
+alter table public.podcasts
+  add constraint podcasts_crop_mode_check check (crop_mode in ('none', 'center_crop', 'smart_crop'));
+
+alter table public.clips
+  add column if not exists export_mode text not null default 'landscape',
+  add column if not exists crop_mode text not null default 'none',
+  add column if not exists mobile_optimized boolean not null default false,
+  add column if not exists face_tracking_enabled boolean not null default false;
+
+alter table public.clips
+  drop constraint if exists clips_export_mode_check;
+
+alter table public.clips
+  add constraint clips_export_mode_check check (export_mode in ('landscape', 'portrait'));
+
+alter table public.clips
+  drop constraint if exists clips_crop_mode_check;
+
+alter table public.clips
+  add constraint clips_crop_mode_check check (crop_mode in ('none', 'center_crop', 'smart_crop'));

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -12,6 +12,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.models.analysis import ScoreSegment  # noqa: E402
+from app.models.export_settings import ExportSettingsInput  # noqa: E402
 from app.models.transcription import TranscriptWord, TranscriptionResult  # noqa: E402
 from app.models.overlay import OverlayDecision  # noqa: E402
 import app.services.clipping_service as clipping_service_module  # noqa: E402
@@ -135,8 +136,16 @@ class ClippingServiceTests(unittest.TestCase):
             delete=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=delete_execute)))),
             insert=MagicMock(return_value=SimpleNamespace(execute=insert_execute)),
         )
+        podcasts_update_execute = MagicMock()
+        podcasts_table = SimpleNamespace(
+            update=MagicMock(
+                return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=podcasts_update_execute)))
+            )
+        )
         service_supabase_mock = MagicMock()
-        service_supabase_mock.table.side_effect = lambda name: clips_table if name == "clips" else MagicMock()
+        service_supabase_mock.table.side_effect = (
+            lambda name: clips_table if name == "clips" else podcasts_table if name == "podcasts" else MagicMock()
+        )
 
         def fake_ffmpeg(*args, **kwargs):
             clip_path = args[1]
@@ -156,9 +165,69 @@ class ClippingServiceTests(unittest.TestCase):
 
         self.assertEqual(len(clips), 1)
         self.assertEqual(clips[0].status, "ready")
+        self.assertEqual(clips[0].export_settings.export_mode, "landscape")
         insert_payload = clips_table.insert.call_args.args[0]
         self.assertEqual(insert_payload[0]["podcast_id"], "podcast-123")
         self.assertEqual(insert_payload[0]["status"], "ready")
+        self.assertEqual(insert_payload[0]["export_mode"], "landscape")
+        self.assertEqual(insert_payload[0]["crop_mode"], "none")
+        podcasts_table.update.assert_called_once()
+
+    def test_generate_clips_persists_portrait_export_preferences(self) -> None:
+        case_dir = self._workspace_case_dir("clipping-export-settings")
+        delete_execute = MagicMock()
+        insert_execute = MagicMock()
+        clips_table = SimpleNamespace(
+            delete=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=delete_execute)))),
+            insert=MagicMock(return_value=SimpleNamespace(execute=insert_execute)),
+        )
+        podcasts_eq_mock = MagicMock(return_value=SimpleNamespace(execute=MagicMock()))
+        podcasts_table = SimpleNamespace(update=MagicMock(return_value=SimpleNamespace(eq=podcasts_eq_mock)))
+        service_supabase_mock = MagicMock()
+        service_supabase_mock.table.side_effect = (
+            lambda name: clips_table if name == "clips" else podcasts_table if name == "podcasts" else MagicMock()
+        )
+
+        def fake_ffmpeg(*args, **kwargs):
+            clip_path = args[1]
+            clip_path.write_bytes(b"clip")
+
+        with patch.object(clipping_service_module, "service_supabase", service_supabase_mock):
+            with patch.object(clipping_service_module, "GENERATED_CLIPS_ROOT", case_dir / "generated"):
+                with patch.object(
+                    clipping_service_module,
+                    "_get_podcast_row",
+                    return_value={"id": "podcast-123", "storage_path": "podcast.mp4"},
+                ):
+                    with patch.object(clipping_service_module, "_resolve_source_media_path", return_value=Path("podcast.mp4")):
+                        with patch.object(clipping_service_module, "_run_ffmpeg_clip_generation", side_effect=fake_ffmpeg):
+                            with patch.object(
+                                clipping_service_module,
+                                "_store_clip_assets",
+                                return_value=("https://example.com/clip.mp4", "https://example.com/clip.srt"),
+                            ):
+                                clips = generate_clips(
+                                    "podcast-123",
+                                    self.score_segments,
+                                    self.transcription,
+                                    ExportSettingsInput(
+                                        export_mode="portrait",
+                                        crop_mode="smart_crop",
+                                        face_tracking_enabled=True,
+                                    ),
+                                )
+
+        self.assertEqual(clips[0].export_settings.export_mode, "portrait")
+        self.assertEqual(clips[0].export_settings.crop_mode, "smart_crop")
+        self.assertTrue(clips[0].export_settings.face_tracking_enabled)
+        insert_payload = clips_table.insert.call_args.args[0]
+        self.assertEqual(insert_payload[0]["export_mode"], "portrait")
+        self.assertEqual(insert_payload[0]["crop_mode"], "smart_crop")
+        self.assertTrue(insert_payload[0]["face_tracking_enabled"])
+        podcasts_update_payload = podcasts_table.update.call_args.args[0]
+        self.assertEqual(podcasts_update_payload["export_mode"], "portrait")
+        self.assertEqual(podcasts_update_payload["crop_mode"], "smart_crop")
+        self.assertTrue(podcasts_update_payload["face_tracking_enabled"])
 
     def test_resolve_clip_window_prefers_matching_snippet_over_stale_segment_range(self) -> None:
         stale_segment = ScoreSegment(

--- a/backend/tests/test_export_settings_model.py
+++ b/backend/tests/test_export_settings_model.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.models.export_settings import ExportSettings, ExportSettingsInput  # noqa: E402
+
+
+class ExportSettingsModelTests(unittest.TestCase):
+    def test_portrait_input_defaults_to_center_crop(self) -> None:
+        resolved = ExportSettingsInput(export_mode="portrait").resolve()
+
+        self.assertEqual(resolved.export_mode, "portrait")
+        self.assertEqual(resolved.crop_mode, "center_crop")
+
+    def test_landscape_rejects_crop_modes(self) -> None:
+        with self.assertRaises(ValidationError) as exc_info:
+            ExportSettingsInput(export_mode="landscape", crop_mode="center_crop")
+
+        self.assertIn("Landscape exports only support", str(exc_info.exception))
+
+    def test_face_tracking_requires_smart_crop(self) -> None:
+        with self.assertRaises(ValidationError) as exc_info:
+            ExportSettings(export_mode="portrait", crop_mode="center_crop", face_tracking_enabled=True)
+
+        self.assertIn("Face tracking requires", str(exc_info.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_podcasts_analysis_router.py
+++ b/backend/tests/test_podcasts_analysis_router.py
@@ -15,6 +15,7 @@ if str(BACKEND_ROOT) not in sys.path:
 from app.dependencies.auth import AuthenticatedUser  # noqa: E402
 from app.models.analysis import AnalysisResult, AnalyzePodcastRequest, ScoreSegment  # noqa: E402
 from app.models.clipping import ClipGenerationResult, ClipResult, GenerateClipsRequest  # noqa: E402
+from app.models.export_settings import ExportSettings  # noqa: E402
 from app.models.transcription import TranscriptionResult, TranscriptWord  # noqa: E402
 from app.routers.podcasts import analyze_podcast, generate_podcast_clips  # noqa: E402
 
@@ -78,6 +79,7 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
                 video_url="https://example.com/clip-1.mp4",
                 subtitle_text="A strong subtitle line",
                 status="ready",
+                export_settings=ExportSettings(export_mode="portrait", crop_mode="center_crop"),
             )
         ]
 
@@ -97,6 +99,7 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
                         )
                     ],
                     transcription=self.payload.transcription,
+                    export_settings={"export_mode": "portrait"},
                 ),
                 self.user,
             )
@@ -104,10 +107,12 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
 
         self.assertIsInstance(result, ClipGenerationResult)
         self.assertEqual(result.total_clips_generated, 1)
+        self.assertEqual(result.export_settings.export_mode, "portrait")
         podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
         update_status_mock.assert_any_call("podcast-123", "user-123", "processing")
         update_status_mock.assert_any_call("podcast-123", "user-123", "done")
         generate_clips_mock.assert_called_once()
+        self.assertEqual(generate_clips_mock.call_args.args[3].resolve().export_mode, "portrait")
         analyze_and_score_mock.assert_not_called()
         persist_analysis_result_mock.assert_not_called()
 

--- a/backend/tests/test_publishing_service.py
+++ b/backend/tests/test_publishing_service.py
@@ -171,6 +171,10 @@ class PublishingServiceTests(unittest.TestCase):
                 "published": False,
                 "download_url": None,
                 "published_at": None,
+                "export_mode": "portrait",
+                "crop_mode": "center_crop",
+                "mobile_optimized": True,
+                "face_tracking_enabled": False,
             }
         ]
 
@@ -225,6 +229,8 @@ class PublishingServiceTests(unittest.TestCase):
         self.assertEqual(result.clips[0].download_url, "/podcasts/clips/clip-1/download")
         self.assertIsNotNone(result.clips[0].overlay)
         self.assertEqual(result.clips[0].overlay.overlay_asset, "ai_chip")
+        self.assertEqual(result.export_settings.export_mode, "portrait")
+        self.assertTrue(result.clips[0].export_settings.mobile_optimized)
 
     def test_revoke_clip_download_clears_publication_fields(self) -> None:
         case_dir = self._workspace_case_dir("publishing-revoke")


### PR DESCRIPTION
## Summary
This PR completes Sprint 6 for export format and crop settings API.

## What was added
- export settings backend model and validation
- portrait / landscape request support
- crop mode validation
- persistence of export settings with podcast and clip jobs
- export settings in clip-related API responses
- SQL schema for export settings
- backend test coverage

## Verification
- portrait export settings are accepted and stored
- conflicting format/crop combinations return validation errors
- export settings are available throughout the clip pipeline
