### PR TITLE
Add smart portrait reframing for Sprint 6

### DIFF
--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -14,6 +14,7 @@ from app.models.clipping import ClipGenerationResult, ClipResult
 from app.models.export_settings import ExportSettings, ExportSettingsInput
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.transcription import TranscriptWord, TranscriptionResult
+from app.utils.reframing import CropWindow, build_portrait_video_filters, compute_portrait_crop_window
 import app.services.overlay_mapping_service as overlay_mapping_service_module
 
 
@@ -50,6 +51,8 @@ def build_ffmpeg_clip_command(
     *,
     start_seconds: float,
     duration_seconds: float,
+    export_settings: ExportSettings | None = None,
+    crop_window: CropWindow | None = None,
     overlay: OverlayDecision | None = None,
     overlay_asset_path: Path | None = None,
 ) -> list[str]:
@@ -83,7 +86,12 @@ def build_ffmpeg_clip_command(
         command.extend(
             [
                 "-filter_complex",
-                _build_video_filter_graph(subtitle_path, overlay),
+                _build_video_filter_graph(
+                    subtitle_path,
+                    overlay,
+                    export_settings=export_settings,
+                    crop_window=crop_window,
+                ),
                 "-map",
                 "[vout]",
                 "-map",
@@ -91,7 +99,7 @@ def build_ffmpeg_clip_command(
             ]
         )
     else:
-        command.extend(["-vf", _build_subtitle_filter(subtitle_path)])
+        command.extend(["-vf", _build_video_filters(subtitle_path, export_settings=export_settings, crop_window=crop_window)])
     command.extend(
         [
             "-c:v",
@@ -208,6 +216,7 @@ def generate_clips(
                 subtitle_path,
                 start_seconds=clip_start,
                 duration_seconds=clip_duration,
+                export_settings=resolved_export_settings,
                 overlay=overlay_decision,
             )
             storage_url, subtitle_url = _store_clip_assets(
@@ -549,8 +558,39 @@ def _build_subtitle_filter(subtitle_path: Path) -> str:
     return f"subtitles='{safe_path}':force_style='{style}'"
 
 
-def _build_video_filter_graph(subtitle_path: Path, overlay: OverlayDecision) -> str:
-    subtitle_filter = _build_subtitle_filter(subtitle_path)
+def _build_video_filters(
+    subtitle_path: Path,
+    *,
+    export_settings: ExportSettings | None = None,
+    crop_window: CropWindow | None = None,
+) -> str:
+    filters: list[str] = []
+    if export_settings is not None and export_settings.export_mode == "portrait":
+        portrait_crop = crop_window or CropWindow(
+            source_width=1920,
+            source_height=1080,
+            crop_width=608,
+            crop_height=1080,
+            offset_x=656,
+            offset_y=0,
+        )
+        filters.append(build_portrait_video_filters(portrait_crop))
+    filters.append(_build_subtitle_filter(subtitle_path))
+    return ",".join(filters)
+
+
+def _build_video_filter_graph(
+    subtitle_path: Path,
+    overlay: OverlayDecision,
+    *,
+    export_settings: ExportSettings | None = None,
+    crop_window: CropWindow | None = None,
+) -> str:
+    subtitle_filter = _build_video_filters(
+        subtitle_path,
+        export_settings=export_settings,
+        crop_window=crop_window,
+    )
     opacity = max(0.0, min(float(overlay.opacity or 1.0), 1.0))
     scale = max(0.05, min(float(overlay.scale or 0.18), 0.95))
     start = max(0.0, float(overlay.render_start_seconds or 0.0))
@@ -599,8 +639,15 @@ def _render_clip_with_optional_overlay(
     *,
     start_seconds: float,
     duration_seconds: float,
+    export_settings: ExportSettings,
     overlay: OverlayDecision,
 ) -> OverlayDecision:
+    crop_window = _resolve_crop_window(
+        source_path,
+        start_seconds=start_seconds,
+        duration_seconds=duration_seconds,
+        export_settings=export_settings,
+    )
     if not overlay.applied:
         _run_ffmpeg_clip_generation(
             source_path,
@@ -608,6 +655,8 @@ def _render_clip_with_optional_overlay(
             subtitle_path,
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
+            export_settings=export_settings,
+            crop_window=crop_window,
         )
         return overlay.model_copy(update={"rendered": False, "render_status": "no_match"})
 
@@ -619,6 +668,8 @@ def _render_clip_with_optional_overlay(
             subtitle_path,
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
+            export_settings=export_settings,
+            crop_window=crop_window,
         )
         return overlay.model_copy(update={"rendered": False, "render_status": "missing_asset"})
 
@@ -629,6 +680,8 @@ def _render_clip_with_optional_overlay(
             subtitle_path,
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
+            export_settings=export_settings,
+            crop_window=crop_window,
             overlay=overlay,
             overlay_asset_path=overlay_asset_path,
         )
@@ -640,6 +693,8 @@ def _render_clip_with_optional_overlay(
             subtitle_path,
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
+            export_settings=export_settings,
+            crop_window=crop_window,
         )
         return overlay.model_copy(update={"rendered": False, "render_status": "render_fallback"})
 
@@ -651,6 +706,8 @@ def _run_ffmpeg_clip_generation(
     *,
     start_seconds: float,
     duration_seconds: float,
+    export_settings: ExportSettings | None = None,
+    crop_window: CropWindow | None = None,
     overlay: OverlayDecision | None = None,
     overlay_asset_path: Path | None = None,
 ) -> None:
@@ -663,6 +720,8 @@ def _run_ffmpeg_clip_generation(
         subtitle_path,
         start_seconds=start_seconds,
         duration_seconds=duration_seconds,
+        export_settings=export_settings,
+        crop_window=crop_window,
         overlay=overlay,
         overlay_asset_path=overlay_asset_path,
     )
@@ -797,6 +856,23 @@ def _resolve_export_settings(
     if podcast_row is not None:
         return _build_export_settings_from_row(podcast_row)
     return ExportSettings()
+
+
+def _resolve_crop_window(
+    source_path: Path,
+    *,
+    start_seconds: float,
+    duration_seconds: float,
+    export_settings: ExportSettings,
+) -> CropWindow | None:
+    if export_settings.export_mode != "portrait":
+        return None
+    return compute_portrait_crop_window(
+        source_path,
+        clip_start_seconds=start_seconds,
+        clip_duration_seconds=duration_seconds,
+        prefer_face_detection=export_settings.crop_mode == "smart_crop",
+    )
 
 
 def _build_export_settings_from_row(row: dict[str, Any]) -> ExportSettings:

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -12,10 +12,21 @@ from app.utils.media import (
     inspect_media,
     validate_media_type,
 )
+from app.utils.reframing import (
+    CropWindow,
+    build_portrait_video_filters,
+    compute_portrait_crop_window,
+    detect_primary_face_center_x,
+    read_video_dimensions,
+)
 
 __all__ = [
     "build_ffprobe_command",
+    "build_portrait_video_filters",
+    "compute_portrait_crop_window",
     "CorruptMediaError",
+    "CropWindow",
+    "detect_primary_face_center_x",
     "FFprobeNotAvailableError",
     "MediaFileNotFoundError",
     "MediaInspectionError",
@@ -23,5 +34,6 @@ __all__ = [
     "get_duration_minutes",
     "get_duration_seconds",
     "inspect_media",
+    "read_video_dimensions",
     "validate_media_type",
 ]

--- a/backend/app/utils/reframing.py
+++ b/backend/app/utils/reframing.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import cv2  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - exercised through fallback behavior
+    cv2 = None
+
+
+PORTRAIT_ASPECT_RATIO = 9 / 16
+DEFAULT_PORTRAIT_WIDTH = 1080
+DEFAULT_PORTRAIT_HEIGHT = 1920
+DEFAULT_SAMPLE_COUNT = 5
+
+
+@dataclass(frozen=True)
+class CropWindow:
+    source_width: int
+    source_height: int
+    crop_width: int
+    crop_height: int
+    offset_x: int
+    offset_y: int
+    target_width: int = DEFAULT_PORTRAIT_WIDTH
+    target_height: int = DEFAULT_PORTRAIT_HEIGHT
+    strategy: str = "center_crop"
+    face_detected: bool = False
+
+
+@dataclass(frozen=True)
+class FaceDetection:
+    center_x: float
+    center_y: float
+    width: int
+    height: int
+    weight: float
+
+
+def compute_portrait_crop_window(
+    source_path: Path,
+    *,
+    clip_start_seconds: float,
+    clip_duration_seconds: float,
+    sample_count: int = DEFAULT_SAMPLE_COUNT,
+    prefer_face_detection: bool = True,
+) -> CropWindow:
+    dimensions = read_video_dimensions(source_path)
+    source_width, source_height = dimensions
+    crop_width, crop_height = _resolve_portrait_crop_size(source_width, source_height)
+
+    if crop_width >= source_width:
+        return CropWindow(
+            source_width=source_width,
+            source_height=source_height,
+            crop_width=source_width,
+            crop_height=source_height,
+            offset_x=0,
+            offset_y=0,
+            strategy="full_frame",
+            face_detected=False,
+        )
+
+    face_center_x = None
+    if prefer_face_detection:
+        face_center_x = detect_primary_face_center_x(
+            source_path,
+            clip_start_seconds=clip_start_seconds,
+            clip_duration_seconds=clip_duration_seconds,
+            sample_count=sample_count,
+        )
+    centered_x = int(round((source_width - crop_width) / 2))
+    if face_center_x is None:
+        return CropWindow(
+            source_width=source_width,
+            source_height=source_height,
+            crop_width=crop_width,
+            crop_height=crop_height,
+            offset_x=_clamp(centered_x, 0, source_width - crop_width),
+            offset_y=0,
+            strategy="center_crop",
+            face_detected=False,
+        )
+
+    face_aligned_x = int(round(face_center_x - (crop_width / 2)))
+    return CropWindow(
+        source_width=source_width,
+        source_height=source_height,
+        crop_width=crop_width,
+        crop_height=crop_height,
+        offset_x=_clamp(face_aligned_x, 0, source_width - crop_width),
+        offset_y=0,
+        strategy="smart_crop",
+        face_detected=True,
+    )
+
+
+def build_portrait_video_filters(crop_window: CropWindow) -> str:
+    if crop_window.strategy == "full_frame":
+        return (
+            f"scale={crop_window.target_width}:{crop_window.target_height}:force_original_aspect_ratio=decrease,"
+            f"pad={crop_window.target_width}:{crop_window.target_height}:(ow-iw)/2:(oh-ih)/2"
+        )
+    return (
+        f"crop={crop_window.crop_width}:{crop_window.crop_height}:{crop_window.offset_x}:{crop_window.offset_y},"
+        f"scale={crop_window.target_width}:{crop_window.target_height}"
+    )
+
+
+def detect_primary_face_center_x(
+    source_path: Path,
+    *,
+    clip_start_seconds: float,
+    clip_duration_seconds: float,
+    sample_count: int = DEFAULT_SAMPLE_COUNT,
+) -> float | None:
+    if cv2 is None:
+        return None
+
+    capture = cv2.VideoCapture(str(source_path))
+    if not capture.isOpened():
+        capture.release()
+        return None
+
+    try:
+        classifier = _load_face_classifier()
+        if classifier is None:
+            return None
+
+        frame_centers: list[tuple[float, float]] = []
+        timestamps = _sample_timestamps(
+            clip_start_seconds=clip_start_seconds,
+            clip_duration_seconds=clip_duration_seconds,
+            sample_count=sample_count,
+        )
+        frame_width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH)) or 0
+
+        for timestamp in timestamps:
+            capture.set(cv2.CAP_PROP_POS_MSEC, max(timestamp, 0.0) * 1000.0)
+            ok, frame = capture.read()
+            if not ok or frame is None:
+                continue
+            detection = _detect_most_relevant_face(frame, classifier)
+            if detection is None:
+                continue
+            normalized_center = detection.center_x / max(frame_width or frame.shape[1], 1)
+            frame_centers.append((detection.center_x, detection.weight * max(normalized_center, 0.25)))
+
+        if not frame_centers:
+            return None
+
+        weighted_sum = sum(center * weight for center, weight in frame_centers)
+        total_weight = sum(weight for _, weight in frame_centers)
+        if total_weight <= 0:
+            return None
+        return weighted_sum / total_weight
+    finally:
+        capture.release()
+
+
+def read_video_dimensions(source_path: Path) -> tuple[int, int]:
+    if cv2 is not None:
+        capture = cv2.VideoCapture(str(source_path))
+        if capture.isOpened():
+            try:
+                width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH)) or 0
+                height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 0
+                if width > 0 and height > 0:
+                    return width, height
+            finally:
+                capture.release()
+
+    # Conservative fallback that keeps portrait exports functional when OpenCV is unavailable.
+    return 1920, 1080
+
+
+def _resolve_portrait_crop_size(source_width: int, source_height: int) -> tuple[int, int]:
+    crop_width = int(source_height * PORTRAIT_ASPECT_RATIO)
+    crop_width -= crop_width % 2
+    if crop_width <= 0:
+        crop_width = min(source_width, 2)
+    crop_height = source_height - (source_height % 2)
+    return min(crop_width, source_width), crop_height
+
+
+def _sample_timestamps(
+    *,
+    clip_start_seconds: float,
+    clip_duration_seconds: float,
+    sample_count: int,
+) -> list[float]:
+    bounded_duration = max(float(clip_duration_seconds), 0.0)
+    if bounded_duration == 0:
+        return [max(float(clip_start_seconds), 0.0)]
+    bounded_samples = max(int(sample_count), 1)
+    return [
+        max(float(clip_start_seconds), 0.0) + (bounded_duration * (index + 1) / (bounded_samples + 1))
+        for index in range(bounded_samples)
+    ]
+
+
+def _load_face_classifier() -> Any | None:
+    if cv2 is None:
+        return None
+    cascade_dir = getattr(cv2.data, "haarcascades", None)
+    if not cascade_dir:
+        return None
+    classifier = cv2.CascadeClassifier(str(Path(cascade_dir) / "haarcascade_frontalface_default.xml"))
+    if classifier.empty():
+        return None
+    return classifier
+
+
+def _detect_most_relevant_face(frame: Any, classifier: Any) -> FaceDetection | None:
+    frame_height, frame_width = frame.shape[:2]
+    grayscale = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    faces = classifier.detectMultiScale(
+        grayscale,
+        scaleFactor=1.1,
+        minNeighbors=5,
+        minSize=(48, 48),
+    )
+    if len(faces) == 0:
+        return None
+
+    frame_center_x = frame_width / 2
+    frame_center_y = frame_height / 2
+    best_detection: FaceDetection | None = None
+    best_score = float("-inf")
+
+    for x, y, width, height in faces:
+        center_x = float(x + (width / 2))
+        center_y = float(y + (height / 2))
+        area = float(width * height)
+        distance_penalty = abs(center_x - frame_center_x) + (0.35 * abs(center_y - frame_center_y))
+        score = area - (distance_penalty * 18.0)
+        if score > best_score:
+            best_score = score
+            best_detection = FaceDetection(
+                center_x=center_x,
+                center_y=center_y,
+                width=int(width),
+                height=int(height),
+                weight=max(area, 1.0),
+            )
+
+    return best_detection
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(value, maximum))

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -21,6 +21,7 @@ from app.services.clipping_service import (  # noqa: E402
     build_ffmpeg_clip_command,
     build_srt_content,
     generate_clips,
+    _build_video_filters,
     _resolve_clip_window,
 )
 
@@ -85,6 +86,34 @@ class ClippingServiceTests(unittest.TestCase):
         self.assertIn("aac", command)
         self.assertIn("+faststart", command)
         self.assertIn("subtitles=", command[command.index("-vf") + 1])
+
+    def test_build_ffmpeg_clip_command_adds_portrait_crop_and_scale(self) -> None:
+        command = build_ffmpeg_clip_command(
+            Path("input.mp4"),
+            Path("output.mp4"),
+            Path("captions.srt"),
+            start_seconds=12.345,
+            duration_seconds=18.2,
+            export_settings=ExportSettingsInput(
+                export_mode="portrait",
+                crop_mode="smart_crop",
+                face_tracking_enabled=True,
+            ).resolve(),
+            crop_window=clipping_service_module.CropWindow(
+                source_width=1920,
+                source_height=1080,
+                crop_width=606,
+                crop_height=1080,
+                offset_x=1197,
+                offset_y=0,
+            ),
+        )
+
+        self.assertIn("-vf", command)
+        filters = command[command.index("-vf") + 1]
+        self.assertIn("crop=606:1080:1197:0", filters)
+        self.assertIn("scale=1080:1920", filters)
+        self.assertIn("subtitles=", filters)
 
     def test_build_ffmpeg_clip_command_uses_filter_complex_when_overlay_is_enabled(self) -> None:
         overlay = OverlayDecision(
@@ -228,6 +257,71 @@ class ClippingServiceTests(unittest.TestCase):
         self.assertEqual(podcasts_update_payload["export_mode"], "portrait")
         self.assertEqual(podcasts_update_payload["crop_mode"], "smart_crop")
         self.assertTrue(podcasts_update_payload["face_tracking_enabled"])
+
+    def test_generate_clips_resolves_portrait_crop_window_for_smart_crop_exports(self) -> None:
+        case_dir = self._workspace_case_dir("clipping-smart-crop")
+        clips_table = SimpleNamespace(
+            delete=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=MagicMock())))),
+            insert=MagicMock(return_value=SimpleNamespace(execute=MagicMock())),
+        )
+        podcasts_table = SimpleNamespace(
+            update=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=MagicMock()))))
+        )
+        service_supabase_mock = MagicMock()
+        service_supabase_mock.table.side_effect = (
+            lambda name: clips_table if name == "clips" else podcasts_table if name == "podcasts" else MagicMock()
+        )
+        captured_crop = {}
+
+        def fake_ffmpeg(*args, **kwargs):
+            captured_crop["crop_window"] = kwargs["crop_window"]
+            clip_path = args[1]
+            clip_path.write_bytes(b"clip")
+
+        with patch.object(clipping_service_module, "service_supabase", service_supabase_mock):
+            with patch.object(clipping_service_module, "GENERATED_CLIPS_ROOT", case_dir / "generated"):
+                with patch.object(
+                    clipping_service_module,
+                    "_get_podcast_row",
+                    return_value={"id": "podcast-123", "storage_path": "podcast.mp4"},
+                ):
+                    with patch.object(clipping_service_module, "_resolve_source_media_path", return_value=Path("podcast.mp4")):
+                        with patch.object(
+                            clipping_service_module,
+                            "compute_portrait_crop_window",
+                            return_value=clipping_service_module.CropWindow(
+                                source_width=1920,
+                                source_height=1080,
+                                crop_width=606,
+                                crop_height=1080,
+                                offset_x=1180,
+                                offset_y=0,
+                                strategy="smart_crop",
+                                face_detected=True,
+                            ),
+                        ):
+                            with patch.object(clipping_service_module, "_run_ffmpeg_clip_generation", side_effect=fake_ffmpeg):
+                                with patch.object(
+                                    clipping_service_module,
+                                    "_store_clip_assets",
+                                    return_value=("https://example.com/clip.mp4", "https://example.com/clip.srt"),
+                                ):
+                                    generate_clips(
+                                        "podcast-123",
+                                        self.score_segments,
+                                        self.transcription,
+                                        ExportSettingsInput(
+                                            export_mode="portrait",
+                                            crop_mode="smart_crop",
+                                            face_tracking_enabled=True,
+                                        ),
+                                    )
+
+        self.assertEqual(captured_crop["crop_window"].offset_x, 1180)
+
+    def test_build_video_filters_keeps_landscape_exports_unchanged(self) -> None:
+        filters = _build_video_filters(Path("captions.srt"))
+        self.assertTrue(filters.startswith("subtitles="))
 
     def test_resolve_clip_window_prefers_matching_snippet_over_stale_segment_range(self) -> None:
         stale_segment = ScoreSegment(

--- a/backend/tests/test_media_utils.py
+++ b/backend/tests/test_media_utils.py
@@ -18,6 +18,7 @@ from app.utils.media import (  # noqa: E402
     inspect_media,
     validate_media_type,
 )
+from app.utils.reframing import CropWindow, build_portrait_video_filters, compute_portrait_crop_window  # noqa: E402
 
 
 class MediaUtilsTests(unittest.TestCase):
@@ -62,6 +63,62 @@ class MediaUtilsTests(unittest.TestCase):
         self.assertEqual(result.detected_format, "mov")
         self.assertEqual(result.mime_type, "video/mp4")
         self.assertTrue(result.validation_flags["duration_detected"])
+
+    def test_compute_portrait_crop_window_uses_face_center_when_available(self) -> None:
+        with patch("app.utils.reframing.read_video_dimensions", return_value=(1920, 1080)):
+            with patch("app.utils.reframing.detect_primary_face_center_x", return_value=1500.0):
+                crop = compute_portrait_crop_window(
+                    Path("sample.mp4"),
+                    clip_start_seconds=2.0,
+                    clip_duration_seconds=6.0,
+                )
+
+        self.assertEqual(crop.crop_width, 606)
+        self.assertEqual(crop.offset_x, 1197)
+        self.assertEqual(crop.strategy, "smart_crop")
+        self.assertTrue(crop.face_detected)
+
+    def test_compute_portrait_crop_window_falls_back_to_center_crop_without_face(self) -> None:
+        with patch("app.utils.reframing.read_video_dimensions", return_value=(1920, 1080)):
+            with patch("app.utils.reframing.detect_primary_face_center_x", return_value=None):
+                crop = compute_portrait_crop_window(
+                    Path("sample.mp4"),
+                    clip_start_seconds=0.0,
+                    clip_duration_seconds=4.0,
+                )
+
+        self.assertEqual(crop.offset_x, 657)
+        self.assertEqual(crop.strategy, "center_crop")
+        self.assertFalse(crop.face_detected)
+
+    def test_compute_portrait_crop_window_skips_face_detection_for_center_crop(self) -> None:
+        with patch("app.utils.reframing.read_video_dimensions", return_value=(1920, 1080)):
+            with patch("app.utils.reframing.detect_primary_face_center_x") as detect_mock:
+                crop = compute_portrait_crop_window(
+                    Path("sample.mp4"),
+                    clip_start_seconds=0.0,
+                    clip_duration_seconds=4.0,
+                    prefer_face_detection=False,
+                )
+
+        detect_mock.assert_not_called()
+        self.assertEqual(crop.offset_x, 657)
+        self.assertEqual(crop.strategy, "center_crop")
+
+    def test_build_portrait_video_filters_returns_crop_and_scale_chain(self) -> None:
+        filters = build_portrait_video_filters(
+            CropWindow(
+                source_width=1920,
+                source_height=1080,
+                crop_width=606,
+                crop_height=1080,
+                offset_x=1197,
+                offset_y=0,
+            )
+        )
+
+        self.assertIn("crop=606:1080:1197:0", filters)
+        self.assertIn("scale=1080:1920", filters)
 
 
 if __name__ == "__main__":

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -33,7 +33,7 @@ const EXPORT_MODE_DETAILS: Record<
     label: "Portrait",
     title: "Vertical social export",
     aspect: "9:16",
-    helper: "Optimized for TikTok, Shorts, and Reels with a mobile-first crop.",
+    helper: "Optimized for TikTok, Shorts, and Reels with speaker-aware vertical reframing.",
     platform: "TikTok / Shorts",
     icon: Smartphone,
   },
@@ -51,9 +51,9 @@ function buildExportSettings(exportMode: ExportMode): ExportSettings {
   if (exportMode === "portrait") {
     return {
       export_mode: "portrait",
-      crop_mode: "center_crop",
+      crop_mode: "smart_crop",
       mobile_optimized: true,
-      face_tracking_enabled: false,
+      face_tracking_enabled: true,
     };
   }
 

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -64,9 +64,9 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
         currency: "USD",
         export_settings: {
           export_mode: "portrait",
-          crop_mode: "center_crop",
+          crop_mode: "smart_crop",
           mobile_optimized: true,
-          face_tracking_enabled: false,
+          face_tracking_enabled: true,
         },
       });
     }
@@ -85,9 +85,9 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
         status: "free_ready",
         export_settings: {
           export_mode: "portrait",
-          crop_mode: "center_crop",
+          crop_mode: "smart_crop",
           mobile_optimized: true,
-          face_tracking_enabled: false,
+          face_tracking_enabled: true,
         },
       },
       { token: "token-123" },
@@ -107,9 +107,9 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
         status: "free_ready",
         export_settings: {
           export_mode: "portrait",
-          crop_mode: "center_crop",
+          crop_mode: "smart_crop",
           mobile_optimized: true,
-          face_tracking_enabled: false,
+          face_tracking_enabled: true,
         },
       }),
     );

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,5 @@ psycopg[binary,pool]>=3.2.0
 openai>=1.0.0
 openai-whisper>=20231117
 ffmpeg-python>=0.2.0
+opencv-python-headless>=4.10.0
 supabase>=2.3.0


### PR DESCRIPTION
Completed Sprint 6 by adding smart portrait reframing for clips. Portrait exports now use face detection to keep the speaker centered in 9:16 output, fall back safely to center crop when needed, and are fully wired from the frontend export selector through backend rendering and tests.