### PR TITLE
Add subtitle style backend contract SPRINT 7 (RINESA BISLIMI)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,7 +9,7 @@ from app.models.clip_insights import (
     ClipSearchResponse,
     PodcastClipMetrics,
 )
-from app.models.export_settings import ExportSettings, ExportSettingsInput
+from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle
 from app.models.media import MediaInspectionResult
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.publishing import (
@@ -58,6 +58,7 @@ __all__ = [
     "RecommendationItem",
     "RecommendationResult",
     "ScoreSegment",
+    "SubtitleStyle",
     "TranscriptWord",
     "TranscriptionResult",
     "UploadCalculatePriceRequest",

--- a/backend/app/models/export_settings.py
+++ b/backend/app/models/export_settings.py
@@ -1,11 +1,85 @@
 from __future__ import annotations
 
-from typing import Literal
+import re
+from typing import Any, ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ExportMode = Literal["landscape", "portrait"]
 CropMode = Literal["none", "center_crop", "smart_crop"]
+SubtitleStylePreset = Literal["classic", "bold", "minimal", "boxed"]
+SubtitlePosition = Literal["top", "center", "bottom"]
+
+HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+class SubtitleStyle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    PRESET_OVERRIDES: ClassVar[dict[SubtitleStylePreset, dict[str, Any]]] = {
+        "classic": {},
+        "bold": {
+            "font_size": 24,
+            "background_opacity": 0.25,
+            "bold": True,
+        },
+        "minimal": {
+            "font_size": 16,
+            "outline_color": "#222222",
+            "background_opacity": 0,
+        },
+        "boxed": {
+            "font_size": 20,
+            "background_opacity": 0.55,
+            "bold": True,
+        },
+    }
+
+    preset: SubtitleStylePreset = "classic"
+    font_family: str = Field(default="Arial", min_length=1, max_length=64)
+    font_size: int = Field(default=18, ge=12, le=72)
+    primary_color: str = "#FFFFFF"
+    outline_color: str = "#000000"
+    background_color: str = "#000000"
+    background_opacity: float = Field(default=0.2, ge=0, le=1)
+    position: SubtitlePosition = "bottom"
+    bold: bool = False
+    italic: bool = False
+
+    @field_validator("font_family")
+    @classmethod
+    def validate_font_family(cls, value: str) -> str:
+        cleaned = " ".join(value.split())
+        if not cleaned:
+            raise ValueError("font_family cannot be empty.")
+        if any(character in cleaned for character in ("'", ":", ",", "\\")):
+            raise ValueError("font_family cannot contain quotes, commas, colons, or backslashes.")
+        return cleaned
+
+    @field_validator("primary_color", "outline_color", "background_color")
+    @classmethod
+    def validate_hex_color(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not HEX_COLOR_PATTERN.fullmatch(cleaned):
+            raise ValueError("Subtitle colors must use #RRGGBB hex format.")
+        return cleaned.upper()
+
+    @model_validator(mode="after")
+    def validate_preset_contract(self) -> "SubtitleStyle":
+        for field_name, preset_value in self.PRESET_OVERRIDES[self.preset].items():
+            if field_name not in self.model_fields_set:
+                setattr(self, field_name, preset_value)
+        if self.preset == "minimal" and self.background_opacity > 0:
+            raise ValueError("The minimal subtitle preset requires background_opacity=0.")
+        if self.preset == "boxed" and self.background_opacity <= 0:
+            raise ValueError("The boxed subtitle preset requires background_opacity greater than 0.")
+        if self.preset != "minimal" and self.outline_color == self.primary_color:
+            raise ValueError("outline_color must differ from primary_color.")
+        return self
+
+    @classmethod
+    def for_preset(cls, preset: SubtitleStylePreset) -> "SubtitleStyle":
+        return cls(preset=preset, **cls.PRESET_OVERRIDES[preset])
 
 
 class ExportSettings(BaseModel):
@@ -15,6 +89,7 @@ class ExportSettings(BaseModel):
     crop_mode: CropMode = "none"
     mobile_optimized: bool = False
     face_tracking_enabled: bool = False
+    subtitle_style: SubtitleStyle = Field(default_factory=SubtitleStyle)
 
     @model_validator(mode="after")
     def validate_export_preferences(self) -> "ExportSettings":
@@ -32,6 +107,7 @@ class ExportSettingsInput(BaseModel):
     crop_mode: CropMode | None = None
     mobile_optimized: bool = False
     face_tracking_enabled: bool = False
+    subtitle_style: SubtitleStyle | None = None
 
     @model_validator(mode="after")
     def validate_request_preferences(self) -> "ExportSettingsInput":
@@ -48,4 +124,5 @@ class ExportSettingsInput(BaseModel):
             crop_mode=self.crop_mode or ("center_crop" if self.export_mode == "portrait" else "none"),
             mobile_optimized=self.mobile_optimized,
             face_tracking_enabled=self.face_tracking_enabled,
+            subtitle_style=self.subtitle_style or SubtitleStyle(),
         )

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -11,7 +11,7 @@ from app.config import BACKEND_DIR, ROOT_DIR
 from app.database import UnconfiguredSupabaseClient, service_supabase
 from app.models.analysis import ScoreSegment
 from app.models.clipping import ClipGenerationResult, ClipResult
-from app.models.export_settings import ExportSettings, ExportSettingsInput
+from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.transcription import TranscriptWord, TranscriptionResult
 from app.utils.reframing import CropWindow, build_portrait_video_filters, compute_portrait_crop_window
@@ -257,6 +257,7 @@ def generate_clips(
                     "crop_mode": resolved_export_settings.crop_mode,
                     "mobile_optimized": resolved_export_settings.mobile_optimized,
                     "face_tracking_enabled": resolved_export_settings.face_tracking_enabled,
+                    "subtitle_style": resolved_export_settings.subtitle_style.model_dump(mode="json"),
                 }
             )
         except ClippingError as exc:
@@ -603,14 +604,46 @@ def _format_srt_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{whole_seconds:02d},{milliseconds:03d}"
 
 
-def _build_subtitle_filter(subtitle_path: Path) -> str:
+def _build_subtitle_filter(subtitle_path: Path, subtitle_style: SubtitleStyle | None = None) -> str:
     normalized = subtitle_path.resolve().as_posix().replace(":", r"\:")
     safe_path = normalized.replace("'", r"\'")
-    style = (
-        "FontName=Arial,Fontsize=18,PrimaryColour=&H00FFFFFF,OutlineColour=&H64000000,"
-        "BackColour=&H32000000,BorderStyle=3,Outline=1,Shadow=0,MarginV=32"
-    )
+    style = _build_subtitle_force_style(subtitle_style or SubtitleStyle())
     return f"subtitles='{safe_path}':force_style='{style}'"
+
+
+def _build_subtitle_force_style(subtitle_style: SubtitleStyle) -> str:
+    alignment_by_position = {
+        "top": 8,
+        "center": 5,
+        "bottom": 2,
+    }
+    background_opacity = max(0.0, min(float(subtitle_style.background_opacity), 1.0))
+    border_style = 3 if background_opacity > 0 else 1
+    margin_v = 44 if subtitle_style.position == "bottom" else 32
+    style_parts = {
+        "FontName": subtitle_style.font_family,
+        "Fontsize": str(subtitle_style.font_size),
+        "PrimaryColour": _hex_to_ass_color(subtitle_style.primary_color, opacity=1),
+        "OutlineColour": _hex_to_ass_color(subtitle_style.outline_color, opacity=0.6),
+        "BackColour": _hex_to_ass_color(subtitle_style.background_color, opacity=background_opacity),
+        "BorderStyle": str(border_style),
+        "Outline": "1",
+        "Shadow": "0",
+        "Alignment": str(alignment_by_position[subtitle_style.position]),
+        "MarginV": str(margin_v),
+        "Bold": "-1" if subtitle_style.bold else "0",
+        "Italic": "-1" if subtitle_style.italic else "0",
+    }
+    return ",".join(f"{key}={value}" for key, value in style_parts.items())
+
+
+def _hex_to_ass_color(hex_color: str, *, opacity: float) -> str:
+    cleaned = hex_color.lstrip("#")
+    red = cleaned[0:2]
+    green = cleaned[2:4]
+    blue = cleaned[4:6]
+    alpha = round((1 - max(0.0, min(opacity, 1.0))) * 255)
+    return f"&H{alpha:02X}{blue}{green}{red}"
 
 
 def _build_video_filters(
@@ -630,7 +663,7 @@ def _build_video_filters(
             offset_y=0,
         )
         filters.append(build_portrait_video_filters(portrait_crop))
-    filters.append(_build_subtitle_filter(subtitle_path))
+    filters.append(_build_subtitle_filter(subtitle_path, export_settings.subtitle_style if export_settings else None))
     return ",".join(filters)
 
 
@@ -953,6 +986,7 @@ def _build_export_settings_from_row(row: dict[str, Any]) -> ExportSettings:
         crop_mode=crop_mode,  # type: ignore[arg-type]
         mobile_optimized=bool(row.get("mobile_optimized") or False),
         face_tracking_enabled=bool(row.get("face_tracking_enabled") or False),
+        subtitle_style=row.get("subtitle_style") or SubtitleStyle(),
     )
 
 
@@ -966,6 +1000,7 @@ def _persist_podcast_export_settings(podcast_id: str, export_settings: ExportSet
                 "crop_mode": export_settings.crop_mode,
                 "mobile_optimized": export_settings.mobile_optimized,
                 "face_tracking_enabled": export_settings.face_tracking_enabled,
+                "subtitle_style": export_settings.subtitle_style.model_dump(mode="json"),
             }
         ).eq("id", podcast_id).execute()
     except Exception as exc:
@@ -982,7 +1017,7 @@ def _select_clip_rows_for_podcast(podcast_id: str) -> Any:
         return (
             service_supabase.table("clips")
             .select(
-                "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,export_mode,crop_mode,mobile_optimized,face_tracking_enabled"
+                "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,export_mode,crop_mode,mobile_optimized,face_tracking_enabled,subtitle_style"
             )
             .eq("podcast_id", podcast_id)
             .order("clip_number")
@@ -1006,7 +1041,7 @@ def _select_podcast_row(podcast_id: str) -> Any:
     try:
         return (
             service_supabase.table("podcasts")
-            .select("id,storage_path,export_mode,crop_mode,mobile_optimized,face_tracking_enabled")
+            .select("id,storage_path,export_mode,crop_mode,mobile_optimized,face_tracking_enabled,subtitle_style")
             .eq("id", podcast_id)
             .limit(1)
             .execute()
@@ -1035,6 +1070,7 @@ def _clip_optional_columns_missing(exc: Exception) -> bool:
             "crop_mode",
             "mobile_optimized",
             "face_tracking_enabled",
+            "subtitle_style",
             "42703",
         )
     )
@@ -1049,6 +1085,7 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "crop_mode",
             "mobile_optimized",
             "face_tracking_enabled",
+            "subtitle_style",
             "42703",
         )
     )

--- a/backend/app/services/podcast_service.py
+++ b/backend/app/services/podcast_service.py
@@ -6,7 +6,7 @@ from app.models.podcast import PodcastRecord, PodcastResponse
 
 PODCAST_COLUMNS = (
     "id,user_id,title,duration,status,storage_path,export_mode,crop_mode,"
-    "mobile_optimized,face_tracking_enabled,created_at,updated_at"
+    "mobile_optimized,face_tracking_enabled,subtitle_style,created_at,updated_at"
 )
 
 
@@ -42,6 +42,7 @@ def _build_export_settings(row: dict[str, object]) -> ExportSettings:
         crop_mode=crop_mode,  # type: ignore[arg-type]
         mobile_optimized=mobile_optimized,
         face_tracking_enabled=face_tracking_enabled,
+        subtitle_style=row.get("subtitle_style") or {},
     )
 
 
@@ -143,6 +144,7 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "crop_mode",
             "mobile_optimized",
             "face_tracking_enabled",
+            "subtitle_style",
             "42703",
         )
     )

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -244,6 +244,7 @@ def prepare_upload(
                 "crop_mode": resolved_export_settings.crop_mode,
                 "mobile_optimized": resolved_export_settings.mobile_optimized,
                 "face_tracking_enabled": resolved_export_settings.face_tracking_enabled,
+                "subtitle_style": resolved_export_settings.subtitle_style.model_dump(mode="json"),
             }
         )
 
@@ -257,6 +258,7 @@ def prepare_upload(
         fallback_payload.pop("crop_mode", None)
         fallback_payload.pop("mobile_optimized", None)
         fallback_payload.pop("face_tracking_enabled", None)
+        fallback_payload.pop("subtitle_style", None)
         response = service_supabase.table("podcasts").insert(fallback_payload).execute()
     rows = response.data or []
     if not rows:
@@ -285,6 +287,7 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "crop_mode",
             "mobile_optimized",
             "face_tracking_enabled",
+            "subtitle_style",
             "42703",
         )
     )

--- a/backend/sql/export_settings_schema.sql
+++ b/backend/sql/export_settings_schema.sql
@@ -2,7 +2,8 @@ alter table public.podcasts
   add column if not exists export_mode text not null default 'landscape',
   add column if not exists crop_mode text not null default 'none',
   add column if not exists mobile_optimized boolean not null default false,
-  add column if not exists face_tracking_enabled boolean not null default false;
+  add column if not exists face_tracking_enabled boolean not null default false,
+  add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb;
 
 alter table public.podcasts
   drop constraint if exists podcasts_export_mode_check;
@@ -16,11 +17,61 @@ alter table public.podcasts
 alter table public.podcasts
   add constraint podcasts_crop_mode_check check (crop_mode in ('none', 'center_crop', 'smart_crop'));
 
+alter table public.podcasts
+  drop constraint if exists podcasts_subtitle_style_check;
+
+alter table public.podcasts
+  add constraint podcasts_subtitle_style_check check (
+    jsonb_typeof(subtitle_style) = 'object'
+    and subtitle_style ? 'preset'
+    and subtitle_style ->> 'preset' in ('classic', 'bold', 'minimal', 'boxed')
+    and subtitle_style ? 'font_family'
+    and jsonb_typeof(subtitle_style -> 'font_family') = 'string'
+    and length(trim(subtitle_style ->> 'font_family')) between 1 and 64
+    and subtitle_style ? 'font_size'
+    and case
+      when jsonb_typeof(subtitle_style -> 'font_size') = 'number'
+      then (subtitle_style ->> 'font_size')::integer between 12 and 72
+      else false
+    end
+    and subtitle_style ? 'primary_color'
+    and subtitle_style ->> 'primary_color' ~ '^#[0-9A-Fa-f]{6}$'
+    and subtitle_style ? 'outline_color'
+    and subtitle_style ->> 'outline_color' ~ '^#[0-9A-Fa-f]{6}$'
+    and subtitle_style ? 'background_color'
+    and subtitle_style ->> 'background_color' ~ '^#[0-9A-Fa-f]{6}$'
+    and subtitle_style ? 'background_opacity'
+    and case
+      when jsonb_typeof(subtitle_style -> 'background_opacity') = 'number'
+      then (subtitle_style ->> 'background_opacity')::numeric between 0 and 1
+      else false
+    end
+    and subtitle_style ? 'position'
+    and subtitle_style ->> 'position' in ('top', 'center', 'bottom')
+    and subtitle_style ? 'bold'
+    and jsonb_typeof(subtitle_style -> 'bold') = 'boolean'
+    and subtitle_style ? 'italic'
+    and jsonb_typeof(subtitle_style -> 'italic') = 'boolean'
+    and (
+      subtitle_style ->> 'preset' = 'minimal'
+      or subtitle_style ->> 'outline_color' <> subtitle_style ->> 'primary_color'
+    )
+    and (
+      subtitle_style ->> 'preset' <> 'minimal'
+      or (subtitle_style ->> 'background_opacity')::numeric = 0
+    )
+    and (
+      subtitle_style ->> 'preset' <> 'boxed'
+      or (subtitle_style ->> 'background_opacity')::numeric > 0
+    )
+  );
+
 alter table public.clips
   add column if not exists export_mode text not null default 'landscape',
   add column if not exists crop_mode text not null default 'none',
   add column if not exists mobile_optimized boolean not null default false,
-  add column if not exists face_tracking_enabled boolean not null default false;
+  add column if not exists face_tracking_enabled boolean not null default false,
+  add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb;
 
 alter table public.clips
   drop constraint if exists clips_export_mode_check;
@@ -33,3 +84,52 @@ alter table public.clips
 
 alter table public.clips
   add constraint clips_crop_mode_check check (crop_mode in ('none', 'center_crop', 'smart_crop'));
+
+alter table public.clips
+  drop constraint if exists clips_subtitle_style_check;
+
+alter table public.clips
+  add constraint clips_subtitle_style_check check (
+    jsonb_typeof(subtitle_style) = 'object'
+    and subtitle_style ? 'preset'
+    and subtitle_style ->> 'preset' in ('classic', 'bold', 'minimal', 'boxed')
+    and subtitle_style ? 'font_family'
+    and jsonb_typeof(subtitle_style -> 'font_family') = 'string'
+    and length(trim(subtitle_style ->> 'font_family')) between 1 and 64
+    and subtitle_style ? 'font_size'
+    and case
+      when jsonb_typeof(subtitle_style -> 'font_size') = 'number'
+      then (subtitle_style ->> 'font_size')::integer between 12 and 72
+      else false
+    end
+    and subtitle_style ? 'primary_color'
+    and subtitle_style ->> 'primary_color' ~ '^#[0-9A-Fa-f]{6}$'
+    and subtitle_style ? 'outline_color'
+    and subtitle_style ->> 'outline_color' ~ '^#[0-9A-Fa-f]{6}$'
+    and subtitle_style ? 'background_color'
+    and subtitle_style ->> 'background_color' ~ '^#[0-9A-Fa-f]{6}$'
+    and subtitle_style ? 'background_opacity'
+    and case
+      when jsonb_typeof(subtitle_style -> 'background_opacity') = 'number'
+      then (subtitle_style ->> 'background_opacity')::numeric between 0 and 1
+      else false
+    end
+    and subtitle_style ? 'position'
+    and subtitle_style ->> 'position' in ('top', 'center', 'bottom')
+    and subtitle_style ? 'bold'
+    and jsonb_typeof(subtitle_style -> 'bold') = 'boolean'
+    and subtitle_style ? 'italic'
+    and jsonb_typeof(subtitle_style -> 'italic') = 'boolean'
+    and (
+      subtitle_style ->> 'preset' = 'minimal'
+      or subtitle_style ->> 'outline_color' <> subtitle_style ->> 'primary_color'
+    )
+    and (
+      subtitle_style ->> 'preset' <> 'minimal'
+      or (subtitle_style ->> 'background_opacity')::numeric = 0
+    )
+    and (
+      subtitle_style ->> 'preset' <> 'boxed'
+      or (subtitle_style ->> 'background_opacity')::numeric > 0
+    )
+  );

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -12,7 +12,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.models.analysis import ScoreSegment  # noqa: E402
-from app.models.export_settings import ExportSettingsInput  # noqa: E402
+from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle  # noqa: E402
 from app.models.transcription import TranscriptWord, TranscriptionResult  # noqa: E402
 from app.models.overlay import OverlayDecision  # noqa: E402
 import app.services.clipping_service as clipping_service_module  # noqa: E402
@@ -22,6 +22,7 @@ from app.services.clipping_service import (  # noqa: E402
     build_segment_fallback_srt_content,
     build_srt_content,
     generate_clips,
+    _build_subtitle_force_style,
     _build_video_filters,
     _resolve_clip_window,
 )
@@ -339,6 +340,40 @@ class ClippingServiceTests(unittest.TestCase):
     def test_build_video_filters_keeps_landscape_exports_unchanged(self) -> None:
         filters = _build_video_filters(Path("captions.srt"))
         self.assertTrue(filters.startswith("subtitles="))
+
+    def test_build_video_filters_includes_subtitle_style_for_renderer(self) -> None:
+        filters = _build_video_filters(
+            Path("captions.srt"),
+            export_settings=ExportSettings(
+                subtitle_style=SubtitleStyle(
+                    preset="boxed",
+                    font_family="Inter",
+                    font_size=26,
+                    primary_color="#F8FAFC",
+                    outline_color="#111827",
+                    background_color="#0F172A",
+                    background_opacity=0.7,
+                    position="top",
+                    bold=True,
+                )
+            ),
+        )
+
+        self.assertIn("FontName=Inter", filters)
+        self.assertIn("Fontsize=26", filters)
+        self.assertIn("Alignment=8", filters)
+        self.assertIn("Bold=-1", filters)
+
+    def test_subtitle_force_style_converts_hex_colors_to_ass_format(self) -> None:
+        style = _build_subtitle_force_style(
+            SubtitleStyle(
+                primary_color="#336699",
+                outline_color="#000000",
+            )
+        )
+
+        self.assertIn("PrimaryColour=&H00996633", style)
+        self.assertIn("BackColour=&HCC000000", style)
 
     def test_resolve_clip_window_prefers_matching_snippet_over_stale_segment_range(self) -> None:
         stale_segment = ScoreSegment(

--- a/backend/tests/test_export_settings_model.py
+++ b/backend/tests/test_export_settings_model.py
@@ -10,7 +10,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from app.models.export_settings import ExportSettings, ExportSettingsInput  # noqa: E402
+from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle  # noqa: E402
 
 
 class ExportSettingsModelTests(unittest.TestCase):
@@ -31,6 +31,48 @@ class ExportSettingsModelTests(unittest.TestCase):
             ExportSettings(export_mode="portrait", crop_mode="center_crop", face_tracking_enabled=True)
 
         self.assertIn("Face tracking requires", str(exc_info.exception))
+
+    def test_subtitle_style_accepts_valid_manual_settings(self) -> None:
+        settings = ExportSettingsInput(
+            subtitle_style={
+                "preset": "boxed",
+                "font_family": "Inter",
+                "font_size": 28,
+                "primary_color": "#f8fafc",
+                "outline_color": "#111827",
+                "background_color": "#000000",
+                "background_opacity": 0.6,
+                "position": "top",
+                "bold": True,
+            }
+        ).resolve()
+
+        self.assertEqual(settings.subtitle_style.primary_color, "#F8FAFC")
+        self.assertEqual(settings.subtitle_style.position, "top")
+        self.assertTrue(settings.subtitle_style.bold)
+
+    def test_subtitle_style_rejects_invalid_color(self) -> None:
+        with self.assertRaises(ValidationError) as exc_info:
+            SubtitleStyle(primary_color="white")
+
+        self.assertIn("#RRGGBB", str(exc_info.exception))
+
+    def test_subtitle_style_rejects_invalid_size(self) -> None:
+        with self.assertRaises(ValidationError):
+            SubtitleStyle(font_size=100)
+
+    def test_subtitle_style_supports_named_presets(self) -> None:
+        style = SubtitleStyle.for_preset("bold")
+
+        self.assertEqual(style.preset, "bold")
+        self.assertTrue(style.bold)
+
+    def test_subtitle_style_preset_applies_defaults_with_manual_overrides(self) -> None:
+        style = SubtitleStyle(preset="bold", font_size=30)
+
+        self.assertEqual(style.font_size, 30)
+        self.assertTrue(style.bold)
+        self.assertEqual(style.background_opacity, 0.25)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_upload_service.py
+++ b/backend/tests/test_upload_service.py
@@ -140,6 +140,10 @@ class UploadServiceTests(unittest.TestCase):
                                 export_settings={
                                     "export_mode": "portrait",
                                     "mobile_optimized": True,
+                                    "subtitle_style": {
+                                        "preset": "boxed",
+                                        "background_opacity": 0.5,
+                                    },
                                 },
                             ),
                             self.user,
@@ -150,8 +154,10 @@ class UploadServiceTests(unittest.TestCase):
         self.assertEqual(insert_payload["crop_mode"], "center_crop")
         self.assertTrue(insert_payload["mobile_optimized"])
         self.assertFalse(insert_payload["face_tracking_enabled"])
+        self.assertEqual(insert_payload["subtitle_style"]["preset"], "boxed")
         self.assertEqual(response.export_settings.export_mode, "portrait")
         self.assertEqual(response.export_settings.crop_mode, "center_crop")
+        self.assertEqual(response.export_settings.subtitle_style.preset, "boxed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Completed Sprint 7 backend contract for subtitle style customization.

## Changes
- Added `SubtitleStyle` backend model with preset and manual style support.
- Added validation for subtitle colors, font size, position, background opacity, and preset rules.
- Extended `ExportSettingsInput` and `ExportSettings` with `subtitle_style`.
- Persisted subtitle style settings for podcasts and clips.
- Exposed subtitle style data through upload/export-related responses.
- Connected subtitle style settings to the rendering pipeline through FFmpeg subtitle force style generation.
- Updated Supabase export settings schema with `subtitle_style jsonb` and database constraints.
- Added tests for valid styles, invalid values, preset behavior, upload persistence, and rendering style generation.

## Testing
- `python -m unittest discover backend\tests`
- Result: 103 tests passed.

## Notes
- Frontend UI was not changed in this sprint.
- Supabase needs `backend/sql/export_settings_schema.sql` applied so `subtitle_style` exists in `podcasts` and `clips`.
