### PR TITLE
Feat(audio): add Sprint 8 enhancement pipeline -Rinesa Bislimi

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,7 +9,7 @@ from app.models.clip_insights import (
     ClipSearchResponse,
     PodcastClipMetrics,
 )
-from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle
+from app.models.export_settings import AudioEnhancementSettings, ExportSettings, ExportSettingsInput, SubtitleStyle
 from app.models.media import MediaInspectionResult
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.publishing import (
@@ -36,6 +36,7 @@ __all__ = [
     "AnalysisResult",
     "AnalysisSummary",
     "AnalyzePodcastRequest",
+    "AudioEnhancementSettings",
     "ClipGenerationResult",
     "ClipMetricRow",
     "ClipPublicationResult",

--- a/backend/app/models/export_settings.py
+++ b/backend/app/models/export_settings.py
@@ -9,6 +9,7 @@ ExportMode = Literal["landscape", "portrait"]
 CropMode = Literal["none", "center_crop", "smart_crop"]
 SubtitleStylePreset = Literal["classic", "bold", "minimal", "boxed"]
 SubtitlePosition = Literal["top", "center", "bottom"]
+AudioEnhancementStatus = Literal["enabled", "disabled"]
 
 HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}$")
 
@@ -82,6 +83,25 @@ class SubtitleStyle(BaseModel):
         return cls(preset=preset, **cls.PRESET_OVERRIDES[preset])
 
 
+class AudioEnhancementSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    normalize_loudness: bool = True
+    target_lufs: float = Field(default=-16.0, ge=-24.0, le=-8.0)
+    true_peak_db: float = Field(default=-1.5, ge=-6.0, le=0.0)
+    status: AudioEnhancementStatus = "enabled"
+
+    @model_validator(mode="after")
+    def derive_status_and_flags(self) -> "AudioEnhancementSettings":
+        if not self.enabled:
+            self.normalize_loudness = False
+            self.status = "disabled"
+        else:
+            self.status = "enabled" if self.normalize_loudness else "disabled"
+        return self
+
+
 class ExportSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -90,6 +110,7 @@ class ExportSettings(BaseModel):
     mobile_optimized: bool = False
     face_tracking_enabled: bool = False
     subtitle_style: SubtitleStyle = Field(default_factory=SubtitleStyle)
+    audio_enhancement: AudioEnhancementSettings = Field(default_factory=AudioEnhancementSettings)
 
     @model_validator(mode="after")
     def validate_export_preferences(self) -> "ExportSettings":
@@ -108,6 +129,7 @@ class ExportSettingsInput(BaseModel):
     mobile_optimized: bool = False
     face_tracking_enabled: bool = False
     subtitle_style: SubtitleStyle | None = None
+    audio_enhancement: AudioEnhancementSettings | None = None
 
     @model_validator(mode="after")
     def validate_request_preferences(self) -> "ExportSettingsInput":
@@ -125,4 +147,5 @@ class ExportSettingsInput(BaseModel):
             mobile_optimized=self.mobile_optimized,
             face_tracking_enabled=self.face_tracking_enabled,
             subtitle_style=self.subtitle_style or SubtitleStyle(),
+            audio_enhancement=self.audio_enhancement or AudioEnhancementSettings(),
         )

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -150,6 +150,9 @@ def build_ffmpeg_clip_command(
         )
     else:
         command.extend(["-vf", _build_video_filters(subtitle_path, export_settings=export_settings, crop_window=crop_window)])
+    audio_filter = _build_audio_filter(export_settings)
+    if audio_filter is not None:
+        command.extend(["-af", audio_filter])
     command.extend(
         [
             "-c:v",
@@ -308,6 +311,7 @@ def generate_clips(
                     "mobile_optimized": resolved_export_settings.mobile_optimized,
                     "face_tracking_enabled": resolved_export_settings.face_tracking_enabled,
                     "subtitle_style": resolved_export_settings.subtitle_style.model_dump(mode="json"),
+                    "audio_enhancement": resolved_export_settings.audio_enhancement.model_dump(mode="json"),
                 }
             )
         except ClippingError as exc:
@@ -715,6 +719,18 @@ def _hex_to_ass_color(hex_color: str, *, opacity: float) -> str:
     return f"&H{alpha:02X}{blue}{green}{red}"
 
 
+def _build_audio_filter(export_settings: ExportSettings | None = None) -> str | None:
+    audio_enhancement = (export_settings or ExportSettings()).audio_enhancement
+    if not audio_enhancement.enabled or not audio_enhancement.normalize_loudness:
+        return None
+    return (
+        "loudnorm="
+        f"I={audio_enhancement.target_lufs:.1f}:"
+        f"TP={audio_enhancement.true_peak_db:.1f}:"
+        "LRA=11.0"
+    )
+
+
 def _build_video_filters(
     subtitle_path: Path,
     *,
@@ -1062,6 +1078,7 @@ def _build_export_settings_from_row(row: dict[str, Any]) -> ExportSettings:
         mobile_optimized=bool(row.get("mobile_optimized") or False),
         face_tracking_enabled=bool(row.get("face_tracking_enabled") or False),
         subtitle_style=row.get("subtitle_style") or SubtitleStyle(),
+        audio_enhancement=row.get("audio_enhancement") or {},
     )
 
 
@@ -1076,6 +1093,7 @@ def _persist_podcast_export_settings(podcast_id: str, export_settings: ExportSet
                 "mobile_optimized": export_settings.mobile_optimized,
                 "face_tracking_enabled": export_settings.face_tracking_enabled,
                 "subtitle_style": export_settings.subtitle_style.model_dump(mode="json"),
+                "audio_enhancement": export_settings.audio_enhancement.model_dump(mode="json"),
             }
         ).eq("id", podcast_id).execute()
     except Exception as exc:
@@ -1092,7 +1110,7 @@ def _select_clip_rows_for_podcast(podcast_id: str) -> Any:
         return (
             service_supabase.table("clips")
             .select(
-                "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,export_mode,crop_mode,mobile_optimized,face_tracking_enabled,subtitle_style"
+                "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,export_mode,crop_mode,mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement"
             )
             .eq("podcast_id", podcast_id)
             .order("clip_number")
@@ -1116,7 +1134,7 @@ def _select_podcast_row(podcast_id: str) -> Any:
     try:
         return (
             service_supabase.table("podcasts")
-            .select("id,storage_path,export_mode,crop_mode,mobile_optimized,face_tracking_enabled,subtitle_style")
+            .select("id,storage_path,export_mode,crop_mode,mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement")
             .eq("id", podcast_id)
             .limit(1)
             .execute()
@@ -1146,6 +1164,7 @@ def _clip_optional_columns_missing(exc: Exception) -> bool:
             "mobile_optimized",
             "face_tracking_enabled",
             "subtitle_style",
+            "audio_enhancement",
             "42703",
         )
     )
@@ -1161,6 +1180,7 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "mobile_optimized",
             "face_tracking_enabled",
             "subtitle_style",
+            "audio_enhancement",
             "42703",
         )
     )

--- a/backend/app/services/podcast_service.py
+++ b/backend/app/services/podcast_service.py
@@ -6,7 +6,7 @@ from app.models.podcast import PodcastRecord, PodcastResponse
 
 PODCAST_COLUMNS = (
     "id,user_id,title,duration,status,storage_path,export_mode,crop_mode,"
-    "mobile_optimized,face_tracking_enabled,subtitle_style,created_at,updated_at"
+    "mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement,created_at,updated_at"
 )
 
 
@@ -43,6 +43,7 @@ def _build_export_settings(row: dict[str, object]) -> ExportSettings:
         mobile_optimized=mobile_optimized,
         face_tracking_enabled=face_tracking_enabled,
         subtitle_style=row.get("subtitle_style") or {},
+        audio_enhancement=row.get("audio_enhancement") or {},
     )
 
 
@@ -145,6 +146,7 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "mobile_optimized",
             "face_tracking_enabled",
             "subtitle_style",
+            "audio_enhancement",
             "42703",
         )
     )

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -12,6 +12,7 @@ from app.models.upload import (
     UploadPreflightStatus,
     UploadStatus,
 )
+from app.models.export_settings import ExportSettings
 from app.services.media_service import inspect_staged_media
 from app.services.profile_service import get_profile_by_id, mark_free_trial_used
 from app.utils.media import validate_media_type
@@ -175,7 +176,7 @@ def prepare_upload(
     payload: UploadPrepareRequest,
     current_user: AuthenticatedUser,
 ) -> UploadPrepareResponse:
-    resolved_export_settings = payload.export_settings.resolve() if payload.export_settings else None
+    resolved_export_settings = payload.export_settings.resolve() if payload.export_settings else ExportSettings()
 
     if payload.storage_path:
         if payload.filesize_bytes is None:
@@ -237,16 +238,16 @@ def prepare_upload(
         "mime_type": payload.mime_type,
         "detected_format": calculated_response.detected_format,
     }
-    if resolved_export_settings is not None:
-        insert_payload.update(
-            {
-                "export_mode": resolved_export_settings.export_mode,
-                "crop_mode": resolved_export_settings.crop_mode,
-                "mobile_optimized": resolved_export_settings.mobile_optimized,
-                "face_tracking_enabled": resolved_export_settings.face_tracking_enabled,
-                "subtitle_style": resolved_export_settings.subtitle_style.model_dump(mode="json"),
-            }
-        )
+    insert_payload.update(
+        {
+            "export_mode": resolved_export_settings.export_mode,
+            "crop_mode": resolved_export_settings.crop_mode,
+            "mobile_optimized": resolved_export_settings.mobile_optimized,
+            "face_tracking_enabled": resolved_export_settings.face_tracking_enabled,
+            "subtitle_style": resolved_export_settings.subtitle_style.model_dump(mode="json"),
+            "audio_enhancement": resolved_export_settings.audio_enhancement.model_dump(mode="json"),
+        }
+    )
 
     try:
         response = service_supabase.table("podcasts").insert(insert_payload).execute()
@@ -259,6 +260,7 @@ def prepare_upload(
         fallback_payload.pop("mobile_optimized", None)
         fallback_payload.pop("face_tracking_enabled", None)
         fallback_payload.pop("subtitle_style", None)
+        fallback_payload.pop("audio_enhancement", None)
         response = service_supabase.table("podcasts").insert(fallback_payload).execute()
     rows = response.data or []
     if not rows:
@@ -288,6 +290,7 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "mobile_optimized",
             "face_tracking_enabled",
             "subtitle_style",
+            "audio_enhancement",
             "42703",
         )
     )

--- a/backend/sql/export_settings_schema.sql
+++ b/backend/sql/export_settings_schema.sql
@@ -3,7 +3,8 @@ alter table public.podcasts
   add column if not exists crop_mode text not null default 'none',
   add column if not exists mobile_optimized boolean not null default false,
   add column if not exists face_tracking_enabled boolean not null default false,
-  add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb;
+  add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb,
+  add column if not exists audio_enhancement jsonb not null default '{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}'::jsonb;
 
 alter table public.podcasts
   drop constraint if exists podcasts_export_mode_check;
@@ -66,12 +67,39 @@ alter table public.podcasts
     )
   );
 
+alter table public.podcasts
+  drop constraint if exists podcasts_audio_enhancement_check;
+
+alter table public.podcasts
+  add constraint podcasts_audio_enhancement_check check (
+    jsonb_typeof(audio_enhancement) = 'object'
+    and audio_enhancement ? 'enabled'
+    and jsonb_typeof(audio_enhancement -> 'enabled') = 'boolean'
+    and audio_enhancement ? 'normalize_loudness'
+    and jsonb_typeof(audio_enhancement -> 'normalize_loudness') = 'boolean'
+    and audio_enhancement ? 'target_lufs'
+    and case
+      when jsonb_typeof(audio_enhancement -> 'target_lufs') = 'number'
+      then (audio_enhancement ->> 'target_lufs')::numeric between -24 and -8
+      else false
+    end
+    and audio_enhancement ? 'true_peak_db'
+    and case
+      when jsonb_typeof(audio_enhancement -> 'true_peak_db') = 'number'
+      then (audio_enhancement ->> 'true_peak_db')::numeric between -6 and 0
+      else false
+    end
+    and audio_enhancement ? 'status'
+    and audio_enhancement ->> 'status' in ('enabled', 'disabled')
+  );
+
 alter table public.clips
   add column if not exists export_mode text not null default 'landscape',
   add column if not exists crop_mode text not null default 'none',
   add column if not exists mobile_optimized boolean not null default false,
   add column if not exists face_tracking_enabled boolean not null default false,
-  add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb;
+  add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb,
+  add column if not exists audio_enhancement jsonb not null default '{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}'::jsonb;
 
 alter table public.clips
   drop constraint if exists clips_export_mode_check;
@@ -132,4 +160,30 @@ alter table public.clips
       subtitle_style ->> 'preset' <> 'boxed'
       or (subtitle_style ->> 'background_opacity')::numeric > 0
     )
+  );
+
+alter table public.clips
+  drop constraint if exists clips_audio_enhancement_check;
+
+alter table public.clips
+  add constraint clips_audio_enhancement_check check (
+    jsonb_typeof(audio_enhancement) = 'object'
+    and audio_enhancement ? 'enabled'
+    and jsonb_typeof(audio_enhancement -> 'enabled') = 'boolean'
+    and audio_enhancement ? 'normalize_loudness'
+    and jsonb_typeof(audio_enhancement -> 'normalize_loudness') = 'boolean'
+    and audio_enhancement ? 'target_lufs'
+    and case
+      when jsonb_typeof(audio_enhancement -> 'target_lufs') = 'number'
+      then (audio_enhancement ->> 'target_lufs')::numeric between -24 and -8
+      else false
+    end
+    and audio_enhancement ? 'true_peak_db'
+    and case
+      when jsonb_typeof(audio_enhancement -> 'true_peak_db') = 'number'
+      then (audio_enhancement ->> 'true_peak_db')::numeric between -6 and 0
+      else false
+    end
+    and audio_enhancement ? 'status'
+    and audio_enhancement ->> 'status' in ('enabled', 'disabled')
   );

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -23,6 +23,7 @@ from app.services.clipping_service import (  # noqa: E402
     build_segment_fallback_srt_content,
     build_srt_content,
     generate_clips,
+    _build_audio_filter,
     _build_subtitle_force_style,
     _build_video_filters,
     _resolve_clip_window,
@@ -49,8 +50,15 @@ class ClippingServiceTests(unittest.TestCase):
                 "lavfi",
                 "-i",
                 f"color=c=0x203040:s=1280x720:d={duration_seconds:.2f}",
+                "-f",
+                "lavfi",
+                "-i",
+                f"sine=frequency=440:duration={duration_seconds:.2f}",
                 "-c:v",
                 "libx264",
+                "-c:a",
+                "aac",
+                "-shortest",
                 "-pix_fmt",
                 "yuv420p",
                 str(output_path),
@@ -132,6 +140,8 @@ class ClippingServiceTests(unittest.TestCase):
         self.assertIn("aac", command)
         self.assertIn("+faststart", command)
         self.assertIn("subtitles=", command[command.index("-vf") + 1])
+        self.assertIn("-af", command)
+        self.assertIn("loudnorm=I=-16.0:TP=-1.5:LRA=11.0", command)
 
     def test_build_ffmpeg_clip_command_adds_portrait_crop_and_scale(self) -> None:
         command = build_ffmpeg_clip_command(
@@ -190,8 +200,21 @@ class ClippingServiceTests(unittest.TestCase):
         )
 
         self.assertIn("-filter_complex", command)
+        self.assertIn("-af", command)
         self.assertIn("-map", command)
         self.assertIn("overlay=", command[command.index("-filter_complex") + 1])
+
+    def test_build_ffmpeg_clip_command_skips_audio_filter_when_enhancement_is_disabled(self) -> None:
+        command = build_ffmpeg_clip_command(
+            Path("input.mp4"),
+            Path("output.mp4"),
+            Path("captions.srt"),
+            start_seconds=0,
+            duration_seconds=10,
+            export_settings=ExportSettingsInput(audio_enhancement={"enabled": False}).resolve(),
+        )
+
+        self.assertNotIn("-af", command)
 
     def test_build_srt_content_offsets_timestamps_relative_to_clip_start(self) -> None:
         srt_content, subtitle_text = build_srt_content(
@@ -262,6 +285,7 @@ class ClippingServiceTests(unittest.TestCase):
         self.assertEqual(insert_payload[0]["status"], "ready")
         self.assertEqual(insert_payload[0]["export_mode"], "landscape")
         self.assertEqual(insert_payload[0]["crop_mode"], "none")
+        self.assertEqual(insert_payload[0]["audio_enhancement"]["status"], "enabled")
         podcasts_table.update.assert_called_once()
 
     def test_generate_clips_persists_portrait_export_preferences(self) -> None:
@@ -305,6 +329,11 @@ class ClippingServiceTests(unittest.TestCase):
                                         export_mode="portrait",
                                         crop_mode="smart_crop",
                                         face_tracking_enabled=True,
+                                        audio_enhancement={
+                                            "enabled": True,
+                                            "target_lufs": -14.0,
+                                            "true_peak_db": -1.0,
+                                        },
                                     ),
                                 )
 
@@ -315,10 +344,12 @@ class ClippingServiceTests(unittest.TestCase):
         self.assertEqual(insert_payload[0]["export_mode"], "portrait")
         self.assertEqual(insert_payload[0]["crop_mode"], "smart_crop")
         self.assertTrue(insert_payload[0]["face_tracking_enabled"])
+        self.assertEqual(insert_payload[0]["audio_enhancement"]["target_lufs"], -14.0)
         podcasts_update_payload = podcasts_table.update.call_args.args[0]
         self.assertEqual(podcasts_update_payload["export_mode"], "portrait")
         self.assertEqual(podcasts_update_payload["crop_mode"], "smart_crop")
         self.assertTrue(podcasts_update_payload["face_tracking_enabled"])
+        self.assertEqual(podcasts_update_payload["audio_enhancement"]["true_peak_db"], -1.0)
 
     def test_generate_clips_resolves_portrait_crop_window_for_smart_crop_exports(self) -> None:
         case_dir = self._workspace_case_dir("clipping-smart-crop")
@@ -384,6 +415,19 @@ class ClippingServiceTests(unittest.TestCase):
     def test_build_video_filters_keeps_landscape_exports_unchanged(self) -> None:
         filters = _build_video_filters(Path("captions.srt"))
         self.assertTrue(filters.startswith("subtitles="))
+
+    def test_build_audio_filter_maps_normalization_settings(self) -> None:
+        audio_filter = _build_audio_filter(
+            ExportSettingsInput(
+                audio_enhancement={
+                    "enabled": True,
+                    "target_lufs": -14.0,
+                    "true_peak_db": -1.0,
+                }
+            ).resolve()
+        )
+
+        self.assertEqual(audio_filter, "loudnorm=I=-14.0:TP=-1.0:LRA=11.0")
 
     def test_build_video_filters_includes_subtitle_style_for_renderer(self) -> None:
         filters = _build_video_filters(

--- a/backend/tests/test_export_settings_model.py
+++ b/backend/tests/test_export_settings_model.py
@@ -10,7 +10,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle  # noqa: E402
+from app.models.export_settings import AudioEnhancementSettings, ExportSettings, ExportSettingsInput, SubtitleStyle  # noqa: E402
 
 
 class ExportSettingsModelTests(unittest.TestCase):
@@ -73,6 +73,25 @@ class ExportSettingsModelTests(unittest.TestCase):
         self.assertEqual(style.font_size, 30)
         self.assertTrue(style.bold)
         self.assertEqual(style.background_opacity, 0.25)
+
+    def test_audio_enhancement_defaults_to_enabled_status(self) -> None:
+        settings = ExportSettingsInput().resolve()
+
+        self.assertTrue(settings.audio_enhancement.enabled)
+        self.assertTrue(settings.audio_enhancement.normalize_loudness)
+        self.assertEqual(settings.audio_enhancement.target_lufs, -16.0)
+        self.assertEqual(settings.audio_enhancement.status, "enabled")
+
+    def test_audio_enhancement_can_be_disabled_cleanly(self) -> None:
+        settings = ExportSettingsInput(audio_enhancement={"enabled": False}).resolve()
+
+        self.assertFalse(settings.audio_enhancement.enabled)
+        self.assertFalse(settings.audio_enhancement.normalize_loudness)
+        self.assertEqual(settings.audio_enhancement.status, "disabled")
+
+    def test_audio_enhancement_rejects_unsafe_loudness_target(self) -> None:
+        with self.assertRaises(ValidationError):
+            AudioEnhancementSettings(target_lufs=-40.0)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_upload_service.py
+++ b/backend/tests/test_upload_service.py
@@ -110,6 +110,10 @@ class UploadServiceTests(unittest.TestCase):
         self.assertEqual(response.status, "ready_for_processing")
         self.assertTrue(response.storage_ready)
         self.assertFalse(response.checkout_required)
+        self.assertIsNotNone(response.export_settings)
+        self.assertEqual(response.export_settings.audio_enhancement.status, "enabled")
+        insert_payload = insert_mock.call_args.args[0]
+        self.assertEqual(insert_payload["audio_enhancement"]["status"], "enabled")
         mark_free_trial_used_mock.assert_called_once_with("user-123")
 
     def test_prepare_upload_persists_export_settings(self) -> None:
@@ -144,6 +148,11 @@ class UploadServiceTests(unittest.TestCase):
                                         "preset": "boxed",
                                         "background_opacity": 0.5,
                                     },
+                                    "audio_enhancement": {
+                                        "enabled": True,
+                                        "target_lufs": -14.0,
+                                        "true_peak_db": -1.0,
+                                    },
                                 },
                             ),
                             self.user,
@@ -155,9 +164,13 @@ class UploadServiceTests(unittest.TestCase):
         self.assertTrue(insert_payload["mobile_optimized"])
         self.assertFalse(insert_payload["face_tracking_enabled"])
         self.assertEqual(insert_payload["subtitle_style"]["preset"], "boxed")
+        self.assertTrue(insert_payload["audio_enhancement"]["enabled"])
+        self.assertEqual(insert_payload["audio_enhancement"]["target_lufs"], -14.0)
+        self.assertEqual(insert_payload["audio_enhancement"]["status"], "enabled")
         self.assertEqual(response.export_settings.export_mode, "portrait")
         self.assertEqual(response.export_settings.crop_mode, "center_crop")
         self.assertEqual(response.export_settings.subtitle_style.preset, "boxed")
+        self.assertEqual(response.export_settings.audio_enhancement.true_peak_db, -1.0)
 
 
 if __name__ == "__main__":

--- a/frontend/app/api/upload/prepare/route.ts
+++ b/frontend/app/api/upload/prepare/route.ts
@@ -34,6 +34,13 @@ type PrepareRequestBody = {
       bold: boolean;
       italic: boolean;
     };
+    audio_enhancement?: {
+      enabled: boolean;
+      normalize_loudness: boolean;
+      target_lufs: number;
+      true_peak_db: number;
+      status: "enabled" | "disabled";
+    };
   };
 };
 

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -12,7 +12,7 @@ import {
 import SubtitleStylePanel from "@/components/SubtitleStylePanel";
 import { useAuth } from "@/context/AuthContext";
 import {
-  type ExportMode, type ExportSettings, type PrepareUploadResponse,
+  type AudioEnhancementSettings, type ExportMode, type ExportSettings, type PrepareUploadResponse,
   type SubtitleStyle,
   type UploadPriceResponse, type UploadState,
 } from "@/lib/api";
@@ -26,6 +26,13 @@ import {
 const ACCEPTED_TYPES = ["video/mp4","video/quicktime","video/webm","video/x-m4v"];
 const ACCEPTED_EXT   = [".mp4",".mov",".webm",".m4v"];
 const PREFLIGHT_MODE = process.env.NEXT_PUBLIC_UPLOAD_PREFLIGHT_MODE ?? "real";
+const DEFAULT_AUDIO_ENHANCEMENT: AudioEnhancementSettings = {
+  enabled: true,
+  normalize_loudness: true,
+  target_lufs: -16,
+  true_peak_db: -1.5,
+  status: "enabled",
+};
 const EXPORT_MODE_DETAILS: Record<
   ExportMode,
   {
@@ -63,6 +70,7 @@ function buildExportSettings(exportMode: ExportMode, subtitleStyle: SubtitleStyl
       mobile_optimized: true,
       face_tracking_enabled: true,
       subtitle_style: subtitleStyle,
+      audio_enhancement: DEFAULT_AUDIO_ENHANCEMENT,
     };
   }
 
@@ -72,6 +80,7 @@ function buildExportSettings(exportMode: ExportMode, subtitleStyle: SubtitleStyl
     mobile_optimized: false,
     face_tracking_enabled: false,
     subtitle_style: subtitleStyle,
+    audio_enhancement: DEFAULT_AUDIO_ENHANCEMENT,
   };
 }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -47,12 +47,21 @@ export type SubtitleStyle = {
   italic: boolean;
 };
 
+export type AudioEnhancementSettings = {
+  enabled: boolean;
+  normalize_loudness: boolean;
+  target_lufs: number;
+  true_peak_db: number;
+  status: "enabled" | "disabled";
+};
+
 export type ExportSettings = {
   export_mode: ExportMode;
   crop_mode: CropMode;
   mobile_optimized?: boolean;
   face_tracking_enabled?: boolean;
   subtitle_style?: SubtitleStyle;
+  audio_enhancement?: AudioEnhancementSettings;
 };
 
 export type UploadPriceRequest = {

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -97,6 +97,13 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
             bold: true,
             italic: false,
           },
+          audio_enhancement: {
+            enabled: true,
+            normalize_loudness: true,
+            target_lufs: -14,
+            true_peak_db: -1,
+            status: "enabled",
+          },
         },
       });
     }
@@ -130,6 +137,13 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
             bold: true,
             italic: false,
           },
+          audio_enhancement: {
+            enabled: true,
+            normalize_loudness: true,
+            target_lufs: -14,
+            true_peak_db: -1,
+            status: "enabled",
+          },
         },
       },
       { token: "token-123" },
@@ -138,6 +152,7 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
     assert.equal(result.podcast_id, "pod-portrait");
     assert.equal(result.export_settings?.export_mode, "portrait");
     assert.equal(result.export_settings?.subtitle_style?.preset, "bold");
+    assert.equal(result.export_settings?.audio_enhancement?.status, "enabled");
     assert.equal(calls[0]?.init?.method, "POST");
     assert.equal(
       calls[0]?.init?.body,
@@ -164,6 +179,13 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
             position: "center",
             bold: true,
             italic: false,
+          },
+          audio_enhancement: {
+            enabled: true,
+            normalize_loudness: true,
+            target_lufs: -14,
+            true_peak_db: -1,
+            status: "enabled",
           },
         },
       }),


### PR DESCRIPTION
## Summary
- Adds Sprint 8 audio enhancement settings to the export flow
- Stores audio normalization preferences on podcasts and generated clips
- Returns audio enhancement status in export/API responses
- Applies FFmpeg loudness normalization when audio enhancement is enabled

## Sprint 8 / Issue #48
Completed backend support for audio normalization settings and pipeline flags for Rinesa Bislimi.

## Acceptance Criteria
- Backend accepts and stores normalization settings
- Status shows whether audio enhancement is enabled
- Defaults work without extra configuration
- Media pipeline can use the stored settings

## Testing
- Backend: 38 tests OK
- Frontend API tests passed
- Backend compileall passed
