### PR TITLE
Feat(publishing): add secure user settings API -RINESA BISLIMI

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -1,55 +1,61 @@
-from fastapi import Header, HTTPException, Query, status
-from pydantic import BaseModel, EmailStr
+from fastapi import Depends, HTTPException, Query, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
 
 from app.database import service_supabase
 from app.services.profile_service import get_profile_by_id
 from app.utils.security import decode_backend_token
 
+bearer_scheme = HTTPBearer(auto_error=False)
+
 
 class AuthenticatedUser(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     id: str
     email: EmailStr
     free_trial_used: bool = False
 
+    @field_validator("id")
+    @classmethod
+    def validate_user_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Authenticated user id cannot be empty.")
+        return cleaned
+
 
 async def get_current_user(
-    authorization: str | None = Header(default=None, alias="Authorization"),
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> AuthenticatedUser:
-    if not authorization:
+    if credentials is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authorization header missing.",
         )
 
-    try:
-        scheme, token = authorization.split(" ", 1)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authorization header format.",
-        ) from exc
-
-    if scheme.lower() != "bearer" or not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authorization header format.",
-        )
-
-    return _resolve_authenticated_user(token)
+    return _resolve_authenticated_user(credentials.credentials)
 
 
 async def get_current_user_for_download(
-    authorization: str | None = Header(default=None, alias="Authorization"),
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     access_token: str | None = Query(default=None, alias="access_token"),
 ) -> AuthenticatedUser:
     if access_token:
         return _resolve_authenticated_user(access_token)
 
-    return await get_current_user(authorization)
+    return await get_current_user(credentials)
 
 
 def _resolve_authenticated_user(token: str) -> AuthenticatedUser:
-    backend_payload = decode_backend_token(token)
+    cleaned_token = token.strip()
+    if not cleaned_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authorization header format.",
+        )
+
+    backend_payload = decode_backend_token(cleaned_token)
     if backend_payload:
         return AuthenticatedUser(
             id=str(backend_payload["sub"]),
@@ -58,7 +64,7 @@ def _resolve_authenticated_user(token: str) -> AuthenticatedUser:
         )
 
     try:
-        auth_response = service_supabase.auth.get_user(token)
+        auth_response = service_supabase.auth.get_user(cleaned_token)
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,7 +15,11 @@ from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.publishing import (
     ClipPublicationResult,
     ClipPublicationStatus,
+    ClipPublicationStatusResponse,
     ClipRevocationResult,
+    PublicationDestination,
+    PublicationStatus,
+    PublishClipRequest,
     PublishClipsRequest,
 )
 from app.models.search import (
@@ -41,6 +45,7 @@ __all__ = [
     "ClipMetricRow",
     "ClipPublicationResult",
     "ClipPublicationStatus",
+    "ClipPublicationStatusResponse",
     "ClipRecommendationsResponse",
     "ClipResult",
     "ClipRevocationResult",
@@ -55,6 +60,9 @@ __all__ = [
     "OverlayDecision",
     "OverlayMappingResult",
     "PodcastClipMetrics",
+    "PublicationDestination",
+    "PublicationStatus",
+    "PublishClipRequest",
     "PublishClipsRequest",
     "RecommendationItem",
     "RecommendationResult",

--- a/backend/app/models/profile.py
+++ b/backend/app/models/profile.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, EmailStr, HttpUrl
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+
+from app.models.export_settings import ExportSettings, ExportSettingsInput
 
 
 class ProfileRecord(BaseModel):
@@ -11,6 +13,7 @@ class ProfileRecord(BaseModel):
     free_trial_used: bool = False
     full_name: str | None = None
     profile_picture_url: str | None = None
+    export_settings: ExportSettings = Field(default_factory=ExportSettings)
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -21,10 +24,32 @@ class ProfileResponse(BaseModel):
     free_trial_used: bool
     full_name: str | None = None
     profile_picture_url: str | None = None
+    export_settings: ExportSettings = Field(default_factory=ExportSettings)
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
 
 class UpdateProfileRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     full_name: str | None = None
     profile_picture_url: str | None = None
+
+    @field_validator("full_name", "profile_picture_url")
+    @classmethod
+    def normalize_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = " ".join(value.split())
+        return cleaned or None
+
+
+class UserExportSettingsResponse(BaseModel):
+    user_id: str
+    export_settings: ExportSettings
+
+
+class UpdateUserExportSettingsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    export_settings: ExportSettingsInput

--- a/backend/app/models/publishing.py
+++ b/backend/app/models/publishing.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+PublicationStatus = Literal["pending", "published", "failed"]
+PublicationDestination = Literal["download", "tiktok", "instagram", "youtube", "other"]
 
 
 class ClipPublicationStatus(BaseModel):
@@ -10,8 +14,11 @@ class ClipPublicationStatus(BaseModel):
 
     clip_id: str
     published: bool
+    status: PublicationStatus = "published"
+    destination: PublicationDestination = "download"
     download_url: str | None = None
     published_at: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("clip_id")
     @classmethod
@@ -19,6 +26,21 @@ class ClipPublicationStatus(BaseModel):
         cleaned = value.strip()
         if not cleaned:
             raise ValueError("clip_id cannot be empty.")
+        return cleaned
+
+
+class ClipPublicationStatusResponse(ClipPublicationStatus):
+    model_config = ConfigDict(extra="forbid")
+
+    podcast_id: str
+    updated_at: datetime | None = None
+
+    @field_validator("podcast_id")
+    @classmethod
+    def validate_podcast_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("podcast_id cannot be empty.")
         return cleaned
 
 
@@ -58,4 +80,41 @@ class ClipRevocationResult(BaseModel):
 class PublishClipsRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    clip_ids: list[str] = Field(default_factory=list)
+    clip_ids: list[str] = Field(min_length=1, max_length=50)
+    destination: PublicationDestination = "download"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("clip_ids")
+    @classmethod
+    def validate_clip_ids(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for clip_id in value:
+            cleaned = clip_id.strip()
+            if not cleaned:
+                raise ValueError("clip_ids cannot contain blank values.")
+            if cleaned not in seen:
+                normalized.append(cleaned)
+                seen.add(cleaned)
+        return normalized
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if len(value) > 25:
+            raise ValueError("metadata cannot contain more than 25 fields.")
+        return value
+
+
+class PublishClipRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    destination: PublicationDestination = "download"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if len(value) > 25:
+            raise ValueError("metadata cannot contain more than 25 fields.")
+        return value

--- a/backend/app/routers/clips.py
+++ b/backend/app/routers/clips.py
@@ -1,13 +1,24 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.dependencies.auth import AuthenticatedUser, get_current_user
-from app.models.publishing import ClipRevocationResult
+from app.models.publishing import (
+    ClipPublicationStatus,
+    ClipPublicationStatusResponse,
+    ClipRevocationResult,
+    PublicationDestination,
+    PublishClipRequest,
+)
 from app.models.search import ClipSearchResult
 from app.services.podcast_service import get_podcasts_for_user
 from app.services.search_service import SearchServiceError, search_clips
 from app.services.analysis_service import podcast_belongs_to_user
 from app.services.clipping_service import get_clip_podcast_id
-from app.services.publishing_service import PublishingError, revoke_clip_download
+from app.services.publishing_service import (
+    PublishingError,
+    get_clip_publication_status,
+    publish_clips,
+    revoke_clip_download,
+)
 
 router = APIRouter(prefix="/clips", tags=["clips"])
 
@@ -74,3 +85,60 @@ async def revoke_clip_download_route(
         return revoke_clip_download(clip_id)
     except PublishingError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+@router.post("/{clip_id}/publish", response_model=ClipPublicationStatus)
+async def publish_clip_route(
+    clip_id: str,
+    payload: PublishClipRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> ClipPublicationStatus:
+    podcast_id = get_clip_podcast_id(clip_id)
+    if not podcast_id or not podcast_belongs_to_user(podcast_id, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Clip not found for the current user.",
+        )
+
+    try:
+        result = publish_clips(
+            podcast_id,
+            [clip_id],
+            destination=payload.destination,
+            metadata=payload.metadata,
+        )
+    except PublishingError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if not result.published_clips:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Clip not found for the current user.",
+        )
+    return result.published_clips[0]
+
+
+@router.get("/{clip_id}/publication-status", response_model=ClipPublicationStatusResponse)
+async def get_clip_publication_status_route(
+    clip_id: str,
+    destination: PublicationDestination = Query(default="download"),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> ClipPublicationStatusResponse:
+    podcast_id = get_clip_podcast_id(clip_id)
+    if not podcast_id or not podcast_belongs_to_user(podcast_id, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Clip not found for the current user.",
+        )
+
+    try:
+        publication = get_clip_publication_status(clip_id, destination=destination)
+    except PublishingError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if publication is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Publication status not found for the current user.",
+        )
+    return publication

--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -240,7 +240,13 @@ async def publish_podcast_clips(
         )
 
     try:
-        return await asyncio.to_thread(publish_clips, podcast_id, payload.clip_ids)
+        return await asyncio.to_thread(
+            publish_clips,
+            podcast_id,
+            payload.clip_ids,
+            destination=payload.destination,
+            metadata=payload.metadata,
+        )
     except PublishingError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,8 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.dependencies.auth import AuthenticatedUser, get_current_user
-from app.models.profile import ProfileResponse, UpdateProfileRequest
-from app.services.profile_service import get_profile_by_id, serialize_profile, update_profile
+from app.models.profile import (
+    ProfileResponse,
+    UpdateProfileRequest,
+    UpdateUserExportSettingsRequest,
+    UserExportSettingsResponse,
+)
+from app.services.profile_service import (
+    get_profile_by_id,
+    get_user_export_settings,
+    serialize_profile,
+    update_profile,
+    update_user_export_settings,
+)
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -34,5 +45,33 @@ async def patch_profile(
         current_user.id,
         payload.full_name,
         payload.profile_picture_url,
+        fields_to_update=payload.model_fields_set,
     )
     return serialize_profile(updated)
+
+
+@router.get("/export-settings", response_model=UserExportSettingsResponse)
+async def get_export_settings(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> UserExportSettingsResponse:
+    settings = get_user_export_settings(current_user.id)
+    if not settings:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found.",
+        )
+    return settings
+
+
+@router.patch("/export-settings", response_model=UserExportSettingsResponse)
+async def patch_export_settings(
+    payload: UpdateUserExportSettingsRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> UserExportSettingsResponse:
+    profile = get_profile_by_id(current_user.id)
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found.",
+        )
+    return update_user_export_settings(current_user.id, payload.export_settings)

--- a/backend/app/services/profile_service.py
+++ b/backend/app/services/profile_service.py
@@ -1,14 +1,15 @@
 from app.database import service_supabase
-from app.models.profile import ProfileRecord, ProfileResponse
+from app.models.export_settings import ExportSettings, ExportSettingsInput
+from app.models.profile import ProfileRecord, ProfileResponse, UserExportSettingsResponse
 
-PROFILE_COLUMNS = "id,email,free_trial_used,full_name,profile_picture_url,created_at,updated_at"
+PROFILE_COLUMNS = "id,email,free_trial_used,full_name,profile_picture_url,export_settings,created_at,updated_at"
 
 
 def _normalize_optional_text(value: str | None) -> str | None:
     if value is None:
         return None
 
-    normalized = value.strip()
+    normalized = " ".join(value.split())
     return normalized or None
 
 
@@ -61,20 +62,57 @@ def update_profile(
     profile_id: str,
     full_name: str | None = None,
     profile_picture_url: str | None = None,
+    fields_to_update: set[str] | None = None,
 ) -> ProfileRecord:
+    payload: dict[str, str | None] = {}
+    requested_fields = fields_to_update or {"full_name", "profile_picture_url"}
+    if "full_name" in requested_fields:
+        payload["full_name"] = _normalize_optional_text(full_name)
+    if "profile_picture_url" in requested_fields:
+        payload["profile_picture_url"] = _normalize_optional_text(profile_picture_url)
+    if not payload:
+        profile = get_profile_by_id(profile_id)
+        if not profile:
+            raise ValueError("Profile not found.")
+        return profile
+
     response = (
         service_supabase.table("profiles")
-        .update(
-            {
-                "full_name": _normalize_optional_text(full_name),
-                "profile_picture_url": _normalize_optional_text(profile_picture_url),
-            }
-        )
+        .update(payload)
         .eq("id", profile_id)
         .execute()
     )
     rows = response.data or []
     return ProfileRecord.model_validate(rows[0])
+
+
+def get_user_export_settings(profile_id: str) -> UserExportSettingsResponse | None:
+    profile = get_profile_by_id(profile_id)
+    if not profile:
+        return None
+    return UserExportSettingsResponse(
+        user_id=profile.id,
+        export_settings=profile.export_settings,
+    )
+
+
+def update_user_export_settings(
+    profile_id: str,
+    export_settings: ExportSettingsInput | ExportSettings,
+) -> UserExportSettingsResponse:
+    resolved = export_settings.resolve() if isinstance(export_settings, ExportSettingsInput) else export_settings
+    response = (
+        service_supabase.table("profiles")
+        .update({"export_settings": resolved.model_dump(mode="json")})
+        .eq("id", profile_id)
+        .execute()
+    )
+    rows = response.data or []
+    profile = ProfileRecord.model_validate(rows[0])
+    return UserExportSettingsResponse(
+        user_id=profile.id,
+        export_settings=profile.export_settings,
+    )
 
 
 def serialize_profile(profile: ProfileRecord) -> ProfileResponse:

--- a/backend/app/services/publishing_service.py
+++ b/backend/app/services/publishing_service.py
@@ -6,7 +6,13 @@ import time
 from typing import Any
 
 from app.database import UnconfiguredSupabaseClient, service_supabase
-from app.models.publishing import ClipPublicationResult, ClipPublicationStatus, ClipRevocationResult
+from app.models.publishing import (
+    ClipPublicationResult,
+    ClipPublicationStatus,
+    ClipPublicationStatusResponse,
+    ClipRevocationResult,
+    PublicationDestination,
+)
 from app.services.clipping_service import CLIP_STORAGE_BUCKET, _upload_with_overwrite
 
 PUBLISHED_DOWNLOAD_TTL_SECONDS = 900
@@ -19,7 +25,13 @@ class PublishingError(Exception):
         self.status_code = status_code
 
 
-def publish_clips(podcast_id: str, clip_ids: list[str]) -> ClipPublicationResult:
+def publish_clips(
+    podcast_id: str,
+    clip_ids: list[str],
+    *,
+    destination: PublicationDestination = "download",
+    metadata: dict[str, Any] | None = None,
+) -> ClipPublicationResult:
     started_at = time.perf_counter()
     cleaned_podcast_id = podcast_id.strip()
     if not cleaned_podcast_id:
@@ -28,6 +40,7 @@ def publish_clips(podcast_id: str, clip_ids: list[str]) -> ClipPublicationResult
     normalized_clip_ids = _normalize_clip_ids(clip_ids)
     if not normalized_clip_ids:
         raise PublishingError("At least one clip_id is required.", status_code=400)
+    cleaned_metadata = dict(metadata or {})
     if isinstance(service_supabase, UnconfiguredSupabaseClient):
         raise PublishingError("Supabase must be configured before clips can be published.", status_code=503)
 
@@ -45,10 +58,46 @@ def publish_clips(podcast_id: str, clip_ids: list[str]) -> ClipPublicationResult
     prepared_publications: list[tuple[str, dict[str, Any], ClipPublicationStatus]] = []
 
     for row in ordered_rows:
-        storage_key = _ensure_clip_uploaded(row)
-        _create_storage_signed_url(storage_key)
-
         clip_id = str(row["id"])
+        if str(row.get("status") or "").strip().lower() not in {"ready", "done", "completed"}:
+            _persist_publication_record(
+                clip_id=clip_id,
+                podcast_id=cleaned_podcast_id,
+                destination=destination,
+                status="failed",
+                download_url=None,
+                published_at=None,
+                metadata={**cleaned_metadata, "error": "Clip is not ready for publishing."},
+            )
+            raise PublishingError(
+                f"Clip {clip_id} is not ready for publishing.",
+                status_code=409,
+            )
+
+        _persist_publication_record(
+            clip_id=clip_id,
+            podcast_id=cleaned_podcast_id,
+            destination=destination,
+            status="pending",
+            download_url=None,
+            published_at=None,
+            metadata=cleaned_metadata,
+        )
+        try:
+            storage_key = _ensure_clip_uploaded(row)
+            _create_storage_signed_url(storage_key)
+        except PublishingError as exc:
+            _persist_publication_record(
+                clip_id=clip_id,
+                podcast_id=cleaned_podcast_id,
+                destination=destination,
+                status="failed",
+                download_url=None,
+                published_at=None,
+                metadata={**cleaned_metadata, "error": exc.detail},
+            )
+            raise
+
         download_url = _build_backend_download_path(clip_id)
         payload = {
             "published": True,
@@ -62,14 +111,26 @@ def publish_clips(podcast_id: str, clip_ids: list[str]) -> ClipPublicationResult
                 ClipPublicationStatus(
                     clip_id=clip_id,
                     published=True,
+                    status="published",
+                    destination=destination,
                     download_url=download_url,
                     published_at=published_at,
+                    metadata=cleaned_metadata,
                 ),
             )
         )
 
     for clip_id, payload, _ in prepared_publications:
         service_supabase.table("clips").update(payload).eq("id", clip_id).execute()
+        _persist_publication_record(
+            clip_id=clip_id,
+            podcast_id=cleaned_podcast_id,
+            destination=destination,
+            status="published",
+            download_url=str(payload["download_url"]),
+            published_at=published_at,
+            metadata=cleaned_metadata,
+        )
 
     statuses = [
         status
@@ -127,11 +188,73 @@ def revoke_clip_download(clip_id: str) -> ClipRevocationResult:
             "published_at": None,
         }
     ).eq("id", cleaned_clip_id).execute()
+    _persist_publication_record(
+        clip_id=cleaned_clip_id,
+        podcast_id=str(rows[0].get("podcast_id") or ""),
+        destination="download",
+        status="pending",
+        download_url=None,
+        published_at=None,
+        metadata={"revoked": True},
+    )
 
     return ClipRevocationResult(
         clip_id=cleaned_clip_id,
         revoked=True,
         published=False,
+    )
+
+
+def get_clip_publication_status(
+    clip_id: str,
+    *,
+    destination: PublicationDestination = "download",
+) -> ClipPublicationStatusResponse | None:
+    cleaned_clip_id = clip_id.strip()
+    if not cleaned_clip_id:
+        raise PublishingError("clip_id is required.", status_code=400)
+    if isinstance(service_supabase, UnconfiguredSupabaseClient):
+        raise PublishingError("Supabase must be configured before publication status can be loaded.", status_code=503)
+
+    rows = (
+        service_supabase.table("clip_publications")
+        .select("clip_id,podcast_id,destination,status,download_url,published_at,metadata,updated_at")
+        .eq("clip_id", cleaned_clip_id)
+        .eq("destination", destination)
+        .limit(1)
+        .execute()
+        .data
+        or []
+    )
+    if rows:
+        row = rows[0]
+        return ClipPublicationStatusResponse(
+            clip_id=str(row["clip_id"]),
+            podcast_id=str(row["podcast_id"]),
+            published=str(row.get("status") or "") == "published",
+            status=row.get("status") or "pending",
+            destination=row.get("destination") or destination,
+            download_url=str(row.get("download_url") or "").strip() or None,
+            published_at=row.get("published_at"),
+            metadata=row.get("metadata") or {},
+            updated_at=row.get("updated_at"),
+        )
+
+    clip_rows = _select_clip_rows().eq("id", cleaned_clip_id).limit(1).execute().data or []
+    if not clip_rows:
+        return None
+    row = clip_rows[0]
+    is_published = bool(row.get("published"))
+    return ClipPublicationStatusResponse(
+        clip_id=cleaned_clip_id,
+        podcast_id=str(row.get("podcast_id") or ""),
+        published=is_published,
+        status="published" if is_published else "pending",
+        destination=destination,
+        download_url=str(row.get("download_url") or "").strip() or None,
+        published_at=row.get("published_at"),
+        metadata={},
+        updated_at=None,
     )
 
 
@@ -166,6 +289,36 @@ def _select_clip_rows():
     return service_supabase.table("clips").select(
         "id,podcast_id,clip_number,storage_path,storage_url,status,published,download_url,published_at"
     )
+
+
+def _persist_publication_record(
+    *,
+    clip_id: str,
+    podcast_id: str,
+    destination: PublicationDestination,
+    status: str,
+    download_url: str | None,
+    published_at: datetime | None,
+    metadata: dict[str, Any],
+) -> None:
+    if not podcast_id:
+        return
+
+    updated_at = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "clip_id": clip_id,
+        "podcast_id": podcast_id,
+        "destination": destination,
+        "status": status,
+        "download_url": download_url,
+        "published_at": published_at.isoformat() if published_at else None,
+        "metadata": metadata,
+        "updated_at": updated_at,
+    }
+    service_supabase.table("clip_publications").upsert(
+        payload,
+        on_conflict="clip_id,destination",
+    ).execute()
 
 
 def _ensure_clip_uploaded(row: dict[str, Any]) -> str:

--- a/backend/sql/auth_schema.sql
+++ b/backend/sql/auth_schema.sql
@@ -1,2 +1,22 @@
--- The live project uses public.profiles as the application user table.
--- Apply backend/sql/schema_init.sql in Supabase SQL Editor for the current schema.
+alter table public.profiles
+  add column if not exists export_settings jsonb not null default '{"export_mode":"landscape","crop_mode":"none","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}}'::jsonb;
+
+alter table public.profiles
+  drop constraint if exists profiles_export_settings_check;
+
+alter table public.profiles
+  add constraint profiles_export_settings_check check (
+    jsonb_typeof(export_settings) = 'object'
+    and export_settings ? 'export_mode'
+    and export_settings ->> 'export_mode' in ('landscape', 'portrait')
+    and export_settings ? 'crop_mode'
+    and export_settings ->> 'crop_mode' in ('none', 'center_crop', 'smart_crop')
+    and export_settings ? 'mobile_optimized'
+    and jsonb_typeof(export_settings -> 'mobile_optimized') = 'boolean'
+    and export_settings ? 'face_tracking_enabled'
+    and jsonb_typeof(export_settings -> 'face_tracking_enabled') = 'boolean'
+    and export_settings ? 'subtitle_style'
+    and jsonb_typeof(export_settings -> 'subtitle_style') = 'object'
+    and export_settings ? 'audio_enhancement'
+    and jsonb_typeof(export_settings -> 'audio_enhancement') = 'object'
+  );

--- a/backend/sql/export_settings_schema.sql
+++ b/backend/sql/export_settings_schema.sql
@@ -6,6 +6,9 @@ alter table public.podcasts
   add column if not exists subtitle_style jsonb not null default '{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false}'::jsonb,
   add column if not exists audio_enhancement jsonb not null default '{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}'::jsonb;
 
+alter table public.profiles
+  add column if not exists export_settings jsonb not null default '{"export_mode":"landscape","crop_mode":"none","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}}'::jsonb;
+
 alter table public.podcasts
   drop constraint if exists podcasts_export_mode_check;
 

--- a/backend/sql/publication_schema.sql
+++ b/backend/sql/publication_schema.sql
@@ -7,3 +7,36 @@ alter table public.clips
 
 create index if not exists clips_podcast_published_idx
   on public.clips (podcast_id, published);
+
+create table if not exists public.clip_publications (
+  id uuid primary key default gen_random_uuid(),
+  clip_id uuid not null references public.clips(id) on delete cascade,
+  podcast_id uuid not null references public.podcasts(id) on delete cascade,
+  destination text not null default 'download',
+  status text not null default 'pending',
+  download_url text,
+  published_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (clip_id, destination)
+);
+
+alter table public.clip_publications
+  drop constraint if exists clip_publications_destination_check;
+
+alter table public.clip_publications
+  add constraint clip_publications_destination_check check (
+    destination in ('download', 'tiktok', 'instagram', 'youtube', 'other')
+  );
+
+alter table public.clip_publications
+  drop constraint if exists clip_publications_status_check;
+
+alter table public.clip_publications
+  add constraint clip_publications_status_check check (
+    status in ('pending', 'published', 'failed')
+  );
+
+create index if not exists clip_publications_podcast_status_idx
+  on public.clip_publications (podcast_id, status);

--- a/backend/tests/test_profile_service.py
+++ b/backend/tests/test_profile_service.py
@@ -11,7 +11,8 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 import app.services.profile_service as profile_service_module  # noqa: E402
-from app.services.profile_service import update_profile  # noqa: E402
+from app.models.export_settings import ExportSettingsInput  # noqa: E402
+from app.services.profile_service import update_profile, update_user_export_settings  # noqa: E402
 
 
 class ProfileServiceTests(unittest.TestCase):
@@ -26,6 +27,7 @@ class ProfileServiceTests(unittest.TestCase):
                         "free_trial_used": False,
                         "full_name": None,
                         "profile_picture_url": None,
+                        "export_settings": {},
                         "created_at": None,
                         "updated_at": None,
                     }
@@ -52,6 +54,92 @@ class ProfileServiceTests(unittest.TestCase):
             }
         )
         eq_mock.assert_called_once_with("id", "user-123")
+
+    def test_update_profile_only_persists_requested_patch_fields(self) -> None:
+        service_supabase_mock = MagicMock()
+        execute_mock = MagicMock(
+            return_value=SimpleNamespace(
+                data=[
+                    {
+                        "id": "user-123",
+                        "email": "creator@example.com",
+                        "free_trial_used": False,
+                        "full_name": "Rinesa",
+                        "profile_picture_url": "https://example.com/avatar.png",
+                        "export_settings": {},
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ]
+            )
+        )
+        eq_mock = MagicMock(return_value=SimpleNamespace(execute=execute_mock))
+        update_mock = MagicMock(return_value=SimpleNamespace(eq=eq_mock))
+        table_mock = MagicMock(return_value=SimpleNamespace(update=update_mock))
+        service_supabase_mock.table = table_mock
+
+        with patch.object(profile_service_module, "service_supabase", service_supabase_mock):
+            update_profile("user-123", full_name=" Rinesa  Bislimi ", fields_to_update={"full_name"})
+
+        update_mock.assert_called_once_with({"full_name": "Rinesa Bislimi"})
+
+    def test_update_user_export_settings_persists_resolved_settings(self) -> None:
+        service_supabase_mock = MagicMock()
+        execute_mock = MagicMock(
+            return_value=SimpleNamespace(
+                data=[
+                    {
+                        "id": "user-123",
+                        "email": "creator@example.com",
+                        "free_trial_used": False,
+                        "full_name": None,
+                        "profile_picture_url": None,
+                        "export_settings": {
+                            "export_mode": "portrait",
+                            "crop_mode": "center_crop",
+                            "mobile_optimized": True,
+                            "face_tracking_enabled": False,
+                            "subtitle_style": {
+                                "preset": "classic",
+                                "font_family": "Arial",
+                                "font_size": 18,
+                                "primary_color": "#FFFFFF",
+                                "outline_color": "#000000",
+                                "background_color": "#000000",
+                                "background_opacity": 0.2,
+                                "position": "bottom",
+                                "bold": False,
+                                "italic": False,
+                            },
+                            "audio_enhancement": {
+                                "enabled": True,
+                                "normalize_loudness": True,
+                                "target_lufs": -16.0,
+                                "true_peak_db": -1.5,
+                                "status": "enabled",
+                            },
+                        },
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ]
+            )
+        )
+        eq_mock = MagicMock(return_value=SimpleNamespace(execute=execute_mock))
+        update_mock = MagicMock(return_value=SimpleNamespace(eq=eq_mock))
+        table_mock = MagicMock(return_value=SimpleNamespace(update=update_mock))
+        service_supabase_mock.table = table_mock
+
+        with patch.object(profile_service_module, "service_supabase", service_supabase_mock):
+            response = update_user_export_settings(
+                "user-123",
+                ExportSettingsInput(export_mode="portrait", mobile_optimized=True),
+            )
+
+        self.assertEqual(response.user_id, "user-123")
+        self.assertEqual(response.export_settings.export_mode, "portrait")
+        update_payload = update_mock.call_args.args[0]
+        self.assertEqual(update_payload["export_settings"]["crop_mode"], "center_crop")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_publishing_routes.py
+++ b/backend/tests/test_publishing_routes.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
@@ -18,10 +19,16 @@ from app.dependencies.auth import AuthenticatedUser  # noqa: E402
 from app.models.publishing import (  # noqa: E402
     ClipPublicationResult,
     ClipPublicationStatus,
+    ClipPublicationStatusResponse,
     ClipRevocationResult,
+    PublishClipRequest,
     PublishClipsRequest,
 )
-from app.routers.clips import revoke_clip_download_route  # noqa: E402
+from app.routers.clips import (
+    get_clip_publication_status_route,
+    publish_clip_route,
+    revoke_clip_download_route,
+)  # noqa: E402
 from app.routers.podcasts import download_generated_clip, publish_podcast_clips  # noqa: E402
 
 
@@ -55,6 +62,8 @@ class PublishingRouterTests(unittest.TestCase):
                 ClipPublicationStatus(
                     clip_id="clip-1",
                     published=True,
+                    status="published",
+                    destination="download",
                     download_url="/podcasts/clips/clip-1/download",
                     published_at=datetime(2026, 4, 23, 9, 30, tzinfo=timezone.utc),
                 )
@@ -73,7 +82,36 @@ class PublishingRouterTests(unittest.TestCase):
         self.assertEqual(result.total_clips_published, 1)
         self.assertEqual(result.published_clips[0].clip_id, "clip-1")
         podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
-        publish_clips_mock.assert_called_once_with("podcast-123", ["clip-1"])
+        publish_clips_mock.assert_called_once_with(
+            "podcast-123",
+            ["clip-1"],
+            destination="download",
+            metadata={},
+        )
+
+    @patch("app.routers.podcasts.publish_clips")
+    @patch("app.routers.podcasts.podcast_belongs_to_user", return_value=False)
+    def test_publish_podcast_clips_rejects_unowned_podcast(
+        self,
+        podcast_belongs_mock,
+        publish_clips_mock,
+    ) -> None:
+        with self.assertRaises(HTTPException) as exc_info:
+            asyncio.run(
+                publish_podcast_clips(
+                    "podcast-123",
+                    PublishClipsRequest(clip_ids=["clip-1"]),
+                    self.user,
+                )
+            )
+
+        self.assertEqual(exc_info.exception.status_code, 404)
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        publish_clips_mock.assert_not_called()
+
+    def test_publish_request_rejects_blank_clip_ids(self) -> None:
+        with self.assertRaises(ValidationError):
+            PublishClipsRequest(clip_ids=["clip-1", "   "])
 
     @patch("app.routers.podcasts.record_clip_download")
     @patch(
@@ -171,6 +209,95 @@ class PublishingRouterTests(unittest.TestCase):
         get_clip_podcast_id_mock.assert_called_once_with("clip-1")
         podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
         revoke_clip_download_mock.assert_called_once_with("clip-1")
+
+    @patch("app.routers.clips.publish_clips")
+    @patch("app.routers.clips.podcast_belongs_to_user", return_value=True)
+    @patch("app.routers.clips.get_clip_podcast_id", return_value="podcast-123")
+    def test_publish_clip_route_validates_ownership_and_returns_clip_status(
+        self,
+        get_clip_podcast_id_mock,
+        podcast_belongs_mock,
+        publish_clips_mock,
+    ) -> None:
+        publish_clips_mock.return_value = ClipPublicationResult(
+            podcast_id="podcast-123",
+            total_clips_published=1,
+            published_clips=[
+                ClipPublicationStatus(
+                    clip_id="clip-1",
+                    published=True,
+                    status="published",
+                    destination="instagram",
+                    download_url="/podcasts/clips/clip-1/download",
+                    metadata={"caption": "ready"},
+                )
+            ],
+            processing_time_seconds=0.12,
+        )
+
+        result = asyncio.run(
+            publish_clip_route(
+                "clip-1",
+                PublishClipRequest(destination="instagram", metadata={"caption": "ready"}),
+                self.user,
+            )
+        )
+
+        self.assertEqual(result.status, "published")
+        self.assertEqual(result.destination, "instagram")
+        get_clip_podcast_id_mock.assert_called_once_with("clip-1")
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        publish_clips_mock.assert_called_once_with(
+            "podcast-123",
+            ["clip-1"],
+            destination="instagram",
+            metadata={"caption": "ready"},
+        )
+
+    @patch("app.routers.clips.publish_clips")
+    @patch("app.routers.clips.podcast_belongs_to_user", return_value=False)
+    @patch("app.routers.clips.get_clip_podcast_id", return_value="podcast-123")
+    def test_publish_clip_route_rejects_unowned_clip(
+        self,
+        get_clip_podcast_id_mock,
+        podcast_belongs_mock,
+        publish_clips_mock,
+    ) -> None:
+        with self.assertRaises(HTTPException) as exc_info:
+            asyncio.run(publish_clip_route("clip-1", PublishClipRequest(), self.user))
+
+        self.assertEqual(exc_info.exception.status_code, 404)
+        get_clip_podcast_id_mock.assert_called_once_with("clip-1")
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        publish_clips_mock.assert_not_called()
+
+    @patch("app.routers.clips.get_clip_publication_status")
+    @patch("app.routers.clips.podcast_belongs_to_user", return_value=True)
+    @patch("app.routers.clips.get_clip_podcast_id", return_value="podcast-123")
+    def test_get_clip_publication_status_route_returns_clear_status(
+        self,
+        get_clip_podcast_id_mock,
+        podcast_belongs_mock,
+        get_clip_publication_status_mock,
+    ) -> None:
+        get_clip_publication_status_mock.return_value = ClipPublicationStatusResponse(
+            clip_id="clip-1",
+            podcast_id="podcast-123",
+            published=False,
+            status="failed",
+            destination="youtube",
+            metadata={"error": "upload failed"},
+        )
+
+        result = asyncio.run(
+            get_clip_publication_status_route("clip-1", destination="youtube", current_user=self.user)
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.destination, "youtube")
+        get_clip_podcast_id_mock.assert_called_once_with("clip-1")
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        get_clip_publication_status_mock.assert_called_once_with("clip-1", destination="youtube")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_publishing_service.py
+++ b/backend/tests/test_publishing_service.py
@@ -16,6 +16,7 @@ import app.services.publishing_service as publishing_service_module  # noqa: E40
 from app.services.clipping_service import get_clips_for_podcast  # noqa: E402
 from app.services.publishing_service import (  # noqa: E402
     PublishingError,
+    get_clip_publication_status,
     get_published_clip_download_content,
     publish_clips,
     revoke_clip_download,
@@ -114,6 +115,23 @@ class FakeUpdateQuery:
         return SimpleNamespace(data=updated)
 
 
+class FakeUpsertQuery:
+    def __init__(self, rows: list[dict[str, object]], payload: dict[str, object]) -> None:
+        self._rows = rows
+        self._payload = payload
+
+    def execute(self) -> SimpleNamespace:
+        for index, row in enumerate(self._rows):
+            if (
+                row.get("clip_id") == self._payload.get("clip_id")
+                and row.get("destination") == self._payload.get("destination")
+            ):
+                self._rows[index].update(self._payload)
+                return SimpleNamespace(data=[self._rows[index]])
+        self._rows.append(dict(self._payload))
+        return SimpleNamespace(data=[self._rows[-1]])
+
+
 class FakeClipsTable:
     def __init__(self, rows: list[dict[str, object]]) -> None:
         self.rows = rows
@@ -125,15 +143,31 @@ class FakeClipsTable:
         return FakeUpdateQuery(self.rows, payload)
 
 
+class FakePublicationsTable:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+
+    def upsert(self, payload: dict[str, object], on_conflict: str | None = None) -> FakeUpsertQuery:
+        if on_conflict != "clip_id,destination":
+            raise AssertionError(f"Unexpected conflict target: {on_conflict}")
+        return FakeUpsertQuery(self.rows, payload)
+
+    def select(self, _: str) -> FakeSelectQuery:
+        return FakeSelectQuery(self.rows)
+
+
 class FakeSupabase:
     def __init__(
         self,
         rows: list[dict[str, object]],
         storage: FakeStorage,
         overlay_rows: list[dict[str, object]] | None = None,
+        publication_rows: list[dict[str, object]] | None = None,
     ) -> None:
         self._clips_table = FakeClipsTable(rows)
         self._overlay_rows = overlay_rows or []
+        self.publication_rows = publication_rows if publication_rows is not None else []
+        self._publications_table = FakePublicationsTable(self.publication_rows)
         self.storage = SimpleNamespace(from_=lambda _: storage)
 
     def table(self, name: str):
@@ -141,6 +175,8 @@ class FakeSupabase:
             return self._clips_table
         if name == "clip_overlays":
             return SimpleNamespace(select=lambda _: FakeSelectQuery(self._overlay_rows))
+        if name == "clip_publications":
+            return self._publications_table
         raise AssertionError(f"Unexpected table requested: {name}")
 
 
@@ -186,15 +222,71 @@ class PublishingServiceTests(unittest.TestCase):
         fake_supabase = FakeSupabase(rows, storage)
 
         with patch.object(publishing_service_module, "service_supabase", fake_supabase):
-            result = publish_clips("podcast-123", ["clip-1"])
+            result = publish_clips(
+                "podcast-123",
+                ["clip-1"],
+                destination="youtube",
+                metadata={"caption": "launch"},
+            )
 
         self.assertEqual(result.total_clips_published, 1)
         self.assertTrue(result.published_clips[0].published)
+        self.assertEqual(result.published_clips[0].status, "published")
+        self.assertEqual(result.published_clips[0].destination, "youtube")
+        self.assertEqual(result.published_clips[0].metadata, {"caption": "launch"})
         self.assertEqual(result.published_clips[0].download_url, "/podcasts/clips/clip-1/download")
         self.assertTrue(bool(rows[0]["published"]))
         self.assertEqual(rows[0]["download_url"], "/podcasts/clips/clip-1/download")
         self.assertEqual(rows[0]["storage_path"], original_storage_path)
         self.assertEqual(storage.upload_calls[0][0], "podcast-123/clip-01.mp4")
+        self.assertEqual(fake_supabase.publication_rows[0]["clip_id"], "clip-1")
+        self.assertEqual(fake_supabase.publication_rows[0]["destination"], "youtube")
+        self.assertEqual(fake_supabase.publication_rows[0]["status"], "published")
+
+    def test_get_clip_publication_status_loads_publication_record(self) -> None:
+        case_dir = self._workspace_case_dir("publishing-status")
+        rows = self._build_clip_rows(case_dir)
+        storage = FakeStorage()
+        fake_supabase = FakeSupabase(
+            rows,
+            storage,
+            publication_rows=[
+                {
+                    "clip_id": "clip-1",
+                    "podcast_id": "podcast-123",
+                    "destination": "instagram",
+                    "status": "failed",
+                    "download_url": None,
+                    "published_at": None,
+                    "metadata": {"error": "upload failed"},
+                    "updated_at": "2026-05-05T12:00:00+00:00",
+                }
+            ],
+        )
+
+        with patch.object(publishing_service_module, "service_supabase", fake_supabase):
+            result = get_clip_publication_status("clip-1", destination="instagram")
+
+        self.assertIsNotNone(result)
+        self.assertFalse(result.published)
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.destination, "instagram")
+        self.assertEqual(result.metadata, {"error": "upload failed"})
+
+    def test_publish_clips_rejects_clips_that_are_not_ready(self) -> None:
+        case_dir = self._workspace_case_dir("publishing-not-ready")
+        rows = self._build_clip_rows(case_dir)
+        rows[0]["status"] = "processing"
+        storage = FakeStorage()
+        fake_supabase = FakeSupabase(rows, storage)
+
+        with patch.object(publishing_service_module, "service_supabase", fake_supabase):
+            with self.assertRaises(PublishingError) as exc_info:
+                publish_clips("podcast-123", ["clip-1"])
+
+        self.assertEqual(exc_info.exception.status_code, 409)
+        self.assertIn("not ready", exc_info.exception.detail)
+        self.assertEqual(fake_supabase.publication_rows[0]["status"], "failed")
 
     def test_get_clips_for_podcast_includes_published_metadata(self) -> None:
         case_dir = self._workspace_case_dir("publishing-list")
@@ -249,6 +341,8 @@ class PublishingServiceTests(unittest.TestCase):
         self.assertFalse(bool(rows[0]["published"]))
         self.assertIsNone(rows[0]["download_url"])
         self.assertIsNone(rows[0]["published_at"])
+        self.assertEqual(fake_supabase.publication_rows[0]["status"], "pending")
+        self.assertEqual(fake_supabase.publication_rows[0]["metadata"], {"revoked": True})
 
     def test_publish_clips_surfaces_upload_errors(self) -> None:
         case_dir = self._workspace_case_dir("publishing-error")
@@ -261,6 +355,8 @@ class PublishingServiceTests(unittest.TestCase):
                 publish_clips("podcast-123", ["clip-1"])
 
         self.assertIn("Clip upload failed", exc_info.exception.detail)
+        self.assertEqual(fake_supabase.publication_rows[0]["status"], "failed")
+        self.assertIn("Clip upload failed", str(fake_supabase.publication_rows[0]["metadata"]["error"]))
 
     def test_publish_clips_surfaces_signed_url_generation_errors(self) -> None:
         case_dir = self._workspace_case_dir("publishing-sign-error")


### PR DESCRIPTION
## Summary
- Added protected profile and user export settings API flows.
- Added secure clip publishing endpoints with ownership checks.
- Persisted publication records with destination, status, metadata, and download state.
- Added SQL support for user export settings and clip publication tracking.
- Expanded backend tests for authorization, validation, persistence, and publishing status flows.

## Testing
- `python -m unittest discover backend/tests`
- `python -m compileall -q backend/app`
- Live API checks for authenticated profile/settings, unauthorized access, invalid payloads, and missing clip handling.

## Notes
- This covers Sprint 9 Job 1 / Issue #65.
- Frontend UI changes are not included because this job is focused on backend API, security, persistence, and schema support.
