### PR TITLE
Sprint 10 analytics dashboard and discovery polish

### DIFF
--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -1,7 +1,8 @@
 import asyncio
 import time
+from pathlib import Path
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.responses import FileResponse, Response
 
 from app.dependencies.auth import AuthenticatedUser, get_current_user, get_current_user_for_download
@@ -49,6 +50,62 @@ from app.services.podcast_service import (
 )
 
 router = APIRouter(prefix="/podcasts", tags=["podcasts"])
+
+
+def _is_unsatisfiable_byte_range(range_header: str | None, *, file_size: int) -> bool:
+    if not range_header:
+        return False
+
+    normalized = range_header.strip().lower()
+    if not normalized.startswith("bytes="):
+        return False
+
+    first_range = normalized[6:].split(",", 1)[0].strip()
+    if "-" not in first_range:
+        return False
+
+    start_raw, end_raw = first_range.split("-", 1)
+    try:
+        if start_raw:
+            return int(start_raw) >= file_size
+        if end_raw:
+            return file_size <= 0 or int(end_raw) <= 0
+    except ValueError:
+        return False
+
+    return False
+
+
+def _build_local_file_response(
+    request: Request,
+    file_path: Path,
+    *,
+    filename: str | None = None,
+) -> Response:
+    headers = {"Cache-Control": "no-store"}
+    file_size = file_path.stat().st_size
+
+    # Browsers can reuse a stale byte range after clips are regenerated locally.
+    # Returning the full file avoids a noisy 416 and lets preview/download recover.
+    if _is_unsatisfiable_byte_range(request.headers.get("range"), file_size=file_size):
+        safe_filename = (filename or file_path.name).replace('"', "")
+        return Response(
+            content=file_path.read_bytes(),
+            media_type="video/mp4",
+            headers={
+                **headers,
+                "Accept-Ranges": "bytes",
+                "Content-Length": str(file_size),
+                "Content-Disposition": f'attachment; filename="{safe_filename}"',
+            },
+        )
+
+    return FileResponse(
+        path=file_path,
+        media_type="video/mp4",
+        filename=(filename or file_path.name),
+        headers=headers,
+    )
 
 
 @router.get("", response_model=PodcastsResponse)
@@ -271,6 +328,7 @@ async def publish_podcast_clips(
 @router.get("/clips/{clip_id}/download")
 async def download_generated_clip(
     clip_id: str,
+    request: Request,
     current_user: AuthenticatedUser = Depends(get_current_user_for_download),
 ):
     podcast_id = get_clip_podcast_id(clip_id)
@@ -291,17 +349,17 @@ async def download_generated_clip(
         )
     if file_path and file_path.exists():
         record_clip_download(clip_id)
-        return FileResponse(
-            path=file_path,
-            media_type="video/mp4",
+        return _build_local_file_response(
+            request,
+            file_path,
             filename=(filename or file_path.name),
         )
 
     _, preview_file_path = get_clip_download_target(clip_id)
     if preview_file_path and preview_file_path.exists():
-        return FileResponse(
-            path=preview_file_path,
-            media_type="video/mp4",
+        return _build_local_file_response(
+            request,
+            preview_file_path,
             filename=preview_file_path.name,
         )
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -15,6 +15,7 @@
 
 # next.js
 /.next/
+/.next-*/
 /.next-build/
 /.next-build-webpack/
 /out/

--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -6,14 +6,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowLeft,
   BarChart2,
-  Download,
-  Eye,
   Loader2,
   Moon,
   Sparkles,
   SunMedium,
-  TrendingDown,
-  TrendingUp,
 } from "lucide-react";
 
 import { useAuth } from "@/context/AuthContext";
@@ -24,6 +20,11 @@ import {
   type PodcastClipMetrics,
   type PodcastsResponse,
 } from "@/lib/api";
+import {
+  AnalyticsMetricsDisplay,
+  buildAnalyticsSnapshot,
+  formatAnalyticsChange,
+} from "@/lib/analytics-presentation";
 
 const T = {
   dark: {
@@ -64,11 +65,6 @@ const T = {
   },
 };
 
-function formatChange(value: number): string {
-  const prefix = value > 0 ? "+" : "";
-  return `${prefix}${value.toFixed(1)}%`;
-}
-
 function AnalyticsPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -89,11 +85,9 @@ function AnalyticsPageContent() {
   const selectedPodcast =
     podcasts.find((podcast) => podcast.id === selectedPodcastId) ?? null;
 
-  const topClip = metrics?.top_clips[0] ?? null;
-  const totalVisibility = useMemo(
-    () => (metrics ? metrics.total_views + metrics.total_downloads : 0),
-    [metrics],
-  );
+  const analyticsSnapshot = useMemo(() => buildAnalyticsSnapshot(metrics), [metrics]);
+  const topClip = analyticsSnapshot.topClip;
+  const publishRate = analyticsSnapshot.publishRate;
 
   useEffect(() => {
     const savedTheme = window.localStorage.getItem("insightclips-theme");
@@ -403,7 +397,7 @@ function AnalyticsPageContent() {
                 { label: "Podcasts", value: podcasts.length, sub: "available in analytics" },
                 { label: "Top Views", value: topClip?.views ?? 0, sub: "best clip reach" },
                 { label: "Downloads", value: metrics?.total_downloads ?? 0, sub: "selected podcast total" },
-                { label: "Trend", value: formatChange(metrics?.average_click_trend ?? 0), sub: "average click change" },
+                { label: "Trend", value: formatAnalyticsChange(metrics?.average_click_trend ?? 0), sub: "average click change" },
               ].map((item) => (
                 <div key={item.label}>
                   <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 4 }}>
@@ -520,6 +514,7 @@ function AnalyticsPageContent() {
                 {[
                   `${metrics?.published_clips ?? 0} published clip${metrics?.published_clips === 1 ? "" : "s"} are currently active.`,
                   `${metrics?.unpublished_clips ?? 0} clip${metrics?.unpublished_clips === 1 ? "" : "s"} are still private.`,
+                  `${publishRate}% of this podcast's clips are currently published.`,
                   topClip
                     ? `Clip ${topClip.clip_number} is the current leader for ${selectedPodcast?.title ?? "this podcast"}.`
                     : "Generate and publish clips to populate ranking insights.",
@@ -582,207 +577,23 @@ function AnalyticsPageContent() {
                 ) : null}
               </div>
 
-              {loadingMetrics ? (
-                <div style={{ display: "flex", alignItems: "center", gap: 10, color: t.textSub, padding: "32px 0" }}>
-                  <Loader2 size={20} className="animate-spin" />
-                  Loading clip metrics...
-                </div>
-              ) : !metrics ? (
-                <div style={{ color: t.textSub, lineHeight: 1.8 }}>
-                  No metrics yet for this podcast. Generate clips first to populate analytics.
-                </div>
-              ) : (
-                <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr" : "repeat(4, 1fr)", gap: 14 }}>
-                  {[
-                    { label: "Views", value: metrics.total_views, icon: Eye },
-                    { label: "Downloads", value: metrics.total_downloads, icon: Download },
-                    { label: "Published", value: metrics.published_clips, icon: Sparkles },
-                    {
-                      label: "Click Trend",
-                      value: formatChange(metrics.average_click_trend),
-                      icon: metrics.average_click_trend >= 0 ? TrendingUp : TrendingDown,
-                    },
-                  ].map((item) => (
-                    <div
-                      key={item.label}
-                      className="lift-card"
-                      style={{
-                        borderRadius: 18,
-                        border: `1px solid ${t.borderSub}`,
-                        background: t.cardAlt,
-                        padding: 16,
-                      }}
-                    >
-                      <item.icon size={18} color={t.accent} />
-                      <div style={{ marginTop: 14, fontSize: 10, fontWeight: 700, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint }}>
-                        {item.label}
-                      </div>
-                      <div style={{ marginTop: 6, fontFamily: "'DM Serif Display', serif", fontSize: 30, fontStyle: "italic" }}>
-                        {item.value}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </section>
-
-            <section
-              style={{
-                display: "grid",
-                gridTemplateColumns: isMobile ? "1fr" : "1fr 1fr",
-                gap: 18,
-              }}
-            >
-              <div
-                className="lift-card"
-                style={{
-                  borderRadius: 24,
-                  background: t.card,
-                  border: `1px solid ${t.border}`,
-                  padding: 20,
+              <AnalyticsMetricsDisplay
+                isMobile={isMobile}
+                loadingMetrics={loadingMetrics}
+                metrics={metrics}
+                theme={{
+                  card: t.card,
+                  cardAlt: t.cardAlt,
+                  border: t.border,
+                  borderSub: t.borderSub,
+                  text: t.text,
+                  textSub: t.textSub,
+                  textFaint: t.textFaint,
+                  accent: t.accent,
+                  chip: t.chip,
+                  errorText: t.errorText,
                 }}
-              >
-                <div style={{ fontSize: 11, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 12 }}>
-                  Reach Snapshot
-                </div>
-                <div style={{ fontFamily: "'DM Serif Display', serif", fontSize: 34, lineHeight: 1.04, marginBottom: 8 }}>
-                  {totalVisibility}
-                </div>
-                <div style={{ color: t.textSub, lineHeight: 1.75 }}>
-                  Combined views and downloads across the selected podcast&apos;s top clip set.
-                </div>
-              </div>
-
-              <div
-                className="lift-card"
-                style={{
-                  borderRadius: 24,
-                  background: t.card,
-                  border: `1px solid ${t.border}`,
-                  padding: 20,
-                }}
-              >
-                <div style={{ fontSize: 11, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 12 }}>
-                  Leading Clip
-                </div>
-                {topClip ? (
-                  <>
-                    <div style={{ fontFamily: "'DM Serif Display', serif", fontSize: 30, lineHeight: 1.04 }}>
-                      Clip {topClip.clip_number}
-                    </div>
-                    <div style={{ marginTop: 8, color: t.textSub, lineHeight: 1.75 }}>
-                      {topClip.title}
-                    </div>
-                    <div style={{ marginTop: 12, display: "flex", gap: 10, flexWrap: "wrap" }}>
-                      <span style={{ borderRadius: 999, padding: "7px 10px", background: t.chip, color: t.accent, fontWeight: 700 }}>
-                        {topClip.views} views
-                      </span>
-                      <span style={{ borderRadius: 999, padding: "7px 10px", background: t.cardAlt, border: `1px solid ${t.borderSub}`, color: t.textSub, fontWeight: 700 }}>
-                        {topClip.downloads} downloads
-                      </span>
-                      <span style={{ borderRadius: 999, padding: "7px 10px", background: t.cardAlt, border: `1px solid ${t.borderSub}`, color: t.textSub, fontWeight: 700 }}>
-                        {formatChange(topClip.click_trend)}
-                      </span>
-                    </div>
-                  </>
-                ) : (
-                  <div style={{ color: t.textSub, lineHeight: 1.75 }}>
-                    Once metrics are available, the strongest clip will surface here automatically.
-                  </div>
-                )}
-              </div>
-            </section>
-
-            <section
-              style={{
-                borderRadius: 24,
-                background: t.card,
-                border: `1px solid ${t.border}`,
-                padding: 20,
-              }}
-            >
-              <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center", marginBottom: 16 }}>
-                <div>
-                  <div style={{ fontSize: 11, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
-                    Top Clips Table
-                  </div>
-                  <h3 style={{ margin: 0, fontFamily: "'DM Serif Display', serif", fontSize: 30, lineHeight: 1.05 }}>
-                    Views, downloads, and click trends
-                  </h3>
-                </div>
-                {metrics?.estimated ? (
-                  <div
-                    style={{
-                      borderRadius: 999,
-                      padding: "10px 14px",
-                      background: t.cardAlt,
-                      border: `1px solid ${t.borderSub}`,
-                      color: t.textSub,
-                      fontSize: 13,
-                      fontWeight: 600,
-                    }}
-                  >
-                    Estimated metrics
-                  </div>
-                ) : null}
-              </div>
-
-              {loadingMetrics ? (
-                <div style={{ display: "flex", alignItems: "center", gap: 10, color: t.textSub, padding: "20px 0" }}>
-                  <Loader2 size={18} className="animate-spin" />
-                  Building the ranking table...
-                </div>
-              ) : !metrics || metrics.top_clips.length === 0 ? (
-                <div style={{ color: t.textSub, lineHeight: 1.8 }}>
-                  No top clips available yet for this podcast.
-                </div>
-              ) : (
-                <div style={{ overflowX: "auto" }}>
-                  <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 720 }}>
-                    <thead>
-                      <tr style={{ textAlign: "left", color: t.textFaint, fontSize: 11, letterSpacing: ".18em", textTransform: "uppercase" }}>
-                        <th style={{ padding: "0 0 12px" }}>Clip</th>
-                        <th style={{ padding: "0 0 12px" }}>Views</th>
-                        <th style={{ padding: "0 0 12px" }}>Downloads</th>
-                        <th style={{ padding: "0 0 12px" }}>Click Trend</th>
-                        <th style={{ padding: "0 0 12px" }}>Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {metrics.top_clips.map((clip) => (
-                        <tr key={clip.clip_id} style={{ borderTop: `1px solid ${t.borderSub}` }}>
-                          <td style={{ padding: "14px 0", verticalAlign: "top" }}>
-                            <div style={{ fontWeight: 700 }}>Clip {clip.clip_number}</div>
-                            <div style={{ marginTop: 4, color: t.textSub, lineHeight: 1.65 }}>
-                              {clip.title}
-                            </div>
-                          </td>
-                          <td style={{ padding: "14px 0", fontWeight: 700 }}>{clip.views}</td>
-                          <td style={{ padding: "14px 0", fontWeight: 700 }}>{clip.downloads}</td>
-                          <td style={{ padding: "14px 0", fontWeight: 700, color: clip.click_trend >= 0 ? t.accent : t.errorText }}>
-                            {formatChange(clip.click_trend)}
-                          </td>
-                          <td style={{ padding: "14px 0" }}>
-                            <span
-                              style={{
-                                borderRadius: 999,
-                                padding: "7px 10px",
-                                background: clip.published ? t.chip : t.cardAlt,
-                                border: `1px solid ${clip.published ? t.accent : t.borderSub}`,
-                                color: clip.published ? t.accent : t.textSub,
-                                fontWeight: 700,
-                                fontSize: 12,
-                              }}
-                            >
-                              {clip.published ? "Published" : "Private"}
-                            </span>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
+              />
             </section>
           </main>
         </div>

--- a/frontend/app/clips/page.tsx
+++ b/frontend/app/clips/page.tsx
@@ -917,7 +917,7 @@ function ClipsPageContent() {
                 Search, publish, and ship your strongest moments.
               </h1>
               <p style={{ fontSize: 15, lineHeight: 1.8, color: t.textSub, maxWidth: 700 }}>
-                This board brings clip discovery, publish controls, and recommendation signals into one workflow for Sprint 4.
+                This board brings clip discovery, recommendation signals, and publish controls into one final demo workflow.
               </p>
             </div>
 
@@ -1091,8 +1091,27 @@ function ClipsPageContent() {
                   Loading recommendations...
                 </div>
               ) : recommendations.length === 0 ? (
-                <div style={{ color: t.textSub, lineHeight: 1.75 }}>
-                  Recommendations will appear here after clips are generated for the selected podcast.
+                <div style={{ display: "grid", gap: 12 }}>
+                  <div style={{ color: t.textSub, lineHeight: 1.75 }}>
+                    Recommendations will appear here after clips are generated for the selected podcast.
+                  </div>
+                  {selectedPodcast ? (
+                    <Link
+                      href={`/analytics?podcastId=${selectedPodcast.id}`}
+                      style={{
+                        width: "fit-content",
+                        borderRadius: 999,
+                        padding: "10px 14px",
+                        background: t.cardAlt,
+                        border: `1px solid ${t.borderSub}`,
+                        color: t.textSub,
+                        textDecoration: "none",
+                        fontWeight: 700,
+                      }}
+                    >
+                      Open analytics context
+                    </Link>
+                  ) : null}
                 </div>
               ) : (
                 <div style={{ display: "grid", gap: 10 }}>
@@ -1291,6 +1310,26 @@ function ClipsPageContent() {
                       {option.label}
                     </button>
                   ))}
+                  {activeSearch ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSearchQuery("");
+                        setFilter("all");
+                      }}
+                      style={{
+                        border: `1px solid ${t.borderSub}`,
+                        borderRadius: 999,
+                        padding: "10px 14px",
+                        background: "transparent",
+                        color: t.textSub,
+                        fontWeight: 700,
+                        cursor: "pointer",
+                      }}
+                    >
+                      Clear search
+                    </button>
+                  ) : null}
                 </div>
               </div>
 
@@ -1304,7 +1343,7 @@ function ClipsPageContent() {
                   {searchEstimated
                     ? "Search is using fallback matching from current clip data."
                     : activeSearch
-                      ? "Search is powered by the clip discovery API."
+                      ? `Search is powered by the clip discovery API${selectedPodcast ? ` for ${selectedPodcast.title}` : ""}.`
                       : "Browsing the full generated clip list."}
                 </span>
               </div>
@@ -1346,6 +1385,30 @@ function ClipsPageContent() {
                       ? "Generate clips for this podcast to unlock discovery, recommendations, and publish actions."
                       : "Try another search or filter to surface different clip candidates."}
                   </p>
+                  {clips.length > 0 && activeSearch ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSearchQuery("");
+                        setFilter("all");
+                      }}
+                      style={{
+                        marginTop: 18,
+                        border: `1px solid ${t.borderSub}`,
+                        borderRadius: 999,
+                        background: t.cardAlt,
+                        color: t.textSub,
+                        padding: "12px 18px",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 8,
+                        fontWeight: 700,
+                        cursor: "pointer",
+                      }}
+                    >
+                      Reset search
+                    </button>
+                  ) : null}
                   {clips.length === 0 ? (
                     <button
                       type="button"

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -5,27 +5,26 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
-  LogOut, Moon, Plus, SunMedium, Mic2, Clock,
+  LogOut, Moon, Plus, SunMedium, Mic2, Download,
   Sparkles, Settings, Bell, ChevronRight, Play,
   Activity, Zap, TrendingUp, MoreHorizontal,
   Radio, LayoutDashboard, Library, BarChart2,
-  User, ArrowUpRight, CheckCircle2,
+  User, ArrowUpRight,
 } from "lucide-react";
 
 import { PodcastCard } from "@/components/PodcastCard";
 import { useAuth } from "@/context/AuthContext";
-import { analyzePodcast, getJson, getPodcastAnalysis, type AnalysisSummary } from "@/lib/api";
-
-type ProfileResponse = {
-  id: string; email: string; full_name: string | null;
-  profile_picture_url: string | null; free_trial_used: boolean;
-  created_at: string | null; updated_at: string | null;
-};
-type Podcast = {
-  id: string; user_id: string; title: string; duration: number;
-  status: string; created_at: string | null; updated_at: string | null;
-};
-type PodcastsResponse = { podcasts: Podcast[]; is_mock: boolean };
+import {
+  analyzePodcast,
+  getJson,
+  getPodcastAnalytics,
+  getPodcastAnalysis,
+  type AnalysisSummary,
+  type Podcast,
+  type PodcastsResponse,
+  type ProfileResponse,
+  type UserPodcastAnalytics,
+} from "@/lib/api";
 
 function isDoneStatus(status: string) {
   return ["done", "completed"].includes(status);
@@ -98,9 +97,8 @@ const T = {
 };
 
 /* ─────────────────────── helpers ─────────────────────── */
-function fmtDur(secs: number) {
-  const m = Math.floor(secs / 60);
-  return m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`;
+function formatPercent(value: number) {
+  return `${value.toFixed(1)}%`;
 }
 
 /* ─────────────────────── nav item ─────────────────────── */
@@ -183,6 +181,7 @@ export default function DashboardPage() {
 
   const [profile,   setProfile]   = useState<ProfileResponse | null>(null);
   const [podcasts,  setPodcasts]  = useState<Podcast[]>([]);
+  const [analytics, setAnalytics] = useState<UserPodcastAnalytics | null>(null);
   const [isMock,    setIsMock]    = useState(false);
   const [loading,   setLoading]   = useState(true);
   const [error,     setError]     = useState("");
@@ -228,11 +227,12 @@ export default function DashboardPage() {
       try {
         const token = backendToken ?? (await syncBackendSession());
         if (!token) { router.replace("/login"); return; }
-        const [p, pod] = await Promise.all([
+        const [p, pod, overview] = await Promise.all([
           getJson<ProfileResponse>("/users/profile", token),
           getJson<PodcastsResponse>("/podcasts", token),
+          getPodcastAnalytics(token),
         ]);
-        setProfile(p); setPodcasts(pod.podcasts); setIsMock(pod.is_mock);
+        setProfile(p); setPodcasts(pod.podcasts); setIsMock(pod.is_mock); setAnalytics(overview);
         const analysisEntries = await Promise.all(
           pod.podcasts.map(async (podcast) => {
             try {
@@ -259,7 +259,6 @@ export default function DashboardPage() {
     ),
   }));
 
-  const totalDur   = podcasts.reduce((a, p) => a + (p.duration || 0), 0);
   const processing = podcastsWithEffectiveStatus.filter(p => isProcessingStatus(p.status)).length;
   const payments   = podcastsWithEffectiveStatus.filter(p => isPaymentStatus(p.status)).length;
   const done       = podcastsWithEffectiveStatus.filter(p => isDoneStatus(p.status)).length;
@@ -274,6 +273,51 @@ export default function DashboardPage() {
   );
 
   const firstName = profile?.full_name?.split(" ")[0] ?? null;
+  const visibilityTotal = (analytics?.total_views ?? 0) + (analytics?.total_downloads ?? 0);
+  const comparisonPodcasts = useMemo(() => {
+    const summaries =
+      analytics?.podcasts.map((podcast) => ({
+        podcastId: podcast.podcast_id,
+        title: podcast.title,
+        totalClips: podcast.total_clips,
+        visibility: podcast.total_views + podcast.total_downloads,
+        publishedClips: podcast.published_clips,
+        averageScore: podcast.average_virality_score,
+      })) ??
+      podcastsWithEffectiveStatus.map((podcast) => ({
+        podcastId: podcast.id,
+        title: podcast.title,
+        totalClips: 0,
+        visibility: 0,
+        publishedClips: 0,
+        averageScore: 0,
+      }));
+
+    return [...summaries]
+      .sort((left, right) => {
+        if (right.visibility !== left.visibility) {
+          return right.visibility - left.visibility;
+        }
+        if (right.totalClips !== left.totalClips) {
+          return right.totalClips - left.totalClips;
+        }
+        return left.title.localeCompare(right.title);
+      })
+      .slice(0, 5);
+  }, [analytics?.podcasts, podcastsWithEffectiveStatus]);
+  const comparisonMax = Math.max(
+    1,
+    ...comparisonPodcasts.map((podcast) => podcast.visibility || podcast.totalClips || 1),
+  );
+  const leadingPodcast = comparisonPodcasts[0] ?? null;
+  const leadingClip = analytics?.top_clips[0] ?? null;
+  const generatedClipsByPodcastId = useMemo(
+    () =>
+      Object.fromEntries(
+        (analytics?.podcasts ?? []).map((podcast) => [podcast.podcast_id, podcast.total_clips]),
+      ) as Record<string, number>,
+    [analytics?.podcasts],
+  );
   const notifications = useMemo(() => {
     const items: Array<{
       id: string;
@@ -880,15 +924,17 @@ export default function DashboardPage() {
               </h1>
               <p style={{ fontSize: 14, color: t.textSub, lineHeight: 1.6, fontWeight: 400 }}>
                 {podcasts.length > 0
-                  ? `${podcasts.length} episode${podcasts.length>1?"s":""} in your library${
-                      processing > 0
-                        ? ` · ${processing} processing`
-                        : payments > 0
-                          ? ` · ${payments} awaiting payment`
-                          : done > 0
-                            ? ` · ${done} completed`
-                            : ""
-                    }`
+                  ? analytics && analytics.total_clips > 0
+                    ? `${analytics.total_clips} clip${analytics.total_clips !== 1 ? "s" : ""} across ${analytics.total_podcasts} episode${analytics.total_podcasts !== 1 ? "s" : ""} · ${analytics.published_clips} published · ${visibilityTotal} total reach`
+                    : `${podcasts.length} episode${podcasts.length>1?"s":""} in your library${
+                        processing > 0
+                          ? ` · ${processing} processing`
+                          : payments > 0
+                            ? ` · ${payments} awaiting payment`
+                            : done > 0
+                              ? ` · ${done} completed`
+                              : ""
+                      }`
                   : "Your workspace is ready — upload your first episode to begin."}
               </p>
             </div>
@@ -900,19 +946,19 @@ export default function DashboardPage() {
               gap: 16, marginBottom: 28,
             }}>
               <div className="stat-card">
-                <StatCard icon={Mic2}       label="Podcasts"   value={podcasts.length} sub="total uploaded"          accent="#5a9e3a"  t={t} delay={.10}/>
+                <StatCard icon={Mic2}       label="Podcasts"   value={analytics?.total_podcasts ?? podcasts.length} sub="total uploaded"          accent="#5a9e3a"  t={t} delay={.10}/>
               </div>
               <div className="stat-card">
-                <StatCard icon={Clock}      label="Total audio" value={totalDur ? fmtDur(totalDur) : "0m"} sub="processed audio"  accent="#3a9e88"  t={t} delay={.16}/>
+                <StatCard icon={Play}       label="Total clips" value={analytics?.total_clips ?? 0} sub="generated across the workspace"  accent="#3a9e88"  t={t} delay={.16}/>
               </div>
               <div className="stat-card">
-                <StatCard icon={Activity}   label="Processing"  value={processing}      sub="in the queue"           accent="#9e8a3a"  t={t} delay={.22}/>
+                <StatCard icon={TrendingUp} label="Publish rate" value={formatPercent(analytics?.publish_rate ?? 0)} sub="clips live for download" accent="#9e8a3a"  t={t} delay={.22}/>
               </div>
               <div className="stat-card">
-                <StatCard icon={CheckCircle2} label="Completed" value={done}            sub="ready to export"        accent="#8a5a9e"  t={t} delay={.28}/>
+                <StatCard icon={Activity}   label="Views"      value={analytics?.total_views ?? 0} sub="backend performance count" accent="#8a5a9e"  t={t} delay={.28}/>
               </div>
               <div className="stat-card">
-                <StatCard icon={Clock}      label="Payments"  value={payments}        sub="waiting to continue"   accent="#c98a2d"  t={t} delay={.34}/>
+                <StatCard icon={Download}   label="Downloads" value={analytics?.total_downloads ?? 0} sub="clip exports claimed" accent="#c98a2d"  t={t} delay={.34}/>
               </div>
             </div>
 
@@ -935,33 +981,54 @@ export default function DashboardPage() {
                 >
                   <div style={{ display:"flex", justifyContent:"space-between", alignItems:"flex-start", marginBottom: 20 }}>
                     <div>
-                      <div style={{ fontSize: 10, fontWeight:700, letterSpacing:".2em", textTransform:"uppercase", color:t.textFaint, marginBottom:6 }}>Weekly Uploads</div>
-                      <div style={{ fontFamily:"'DM Serif Display',serif", fontSize: 26, fontStyle:"italic", color:t.accent, lineHeight:1 }}>+18%</div>
+                      <div style={{ fontSize: 10, fontWeight:700, letterSpacing:".2em", textTransform:"uppercase", color:t.textFaint, marginBottom:6 }}>Podcast reach</div>
+                      <div style={{ fontFamily:"'DM Serif Display',serif", fontSize: 26, fontStyle:"italic", color:t.accent, lineHeight:1 }}>
+                        {visibilityTotal || analytics?.total_clips || 0}
+                      </div>
                     </div>
                     <div style={{ display:"flex", alignItems:"center", gap:5 }}>
                       <TrendingUp size={14} color={t.accentLt} strokeWidth={2}/>
-                      <span style={{ fontSize:11, fontWeight:600, color:t.accentLt }}>Growth</span>
+                      <span style={{ fontSize:11, fontWeight:600, color:t.accentLt }}>
+                        {leadingPodcast ? leadingPodcast.title : "Workspace"}
+                      </span>
                     </div>
                   </div>
-                  {/* Bar chart */}
                   <div style={{ display:"flex", alignItems:"flex-end", gap:4, height:60, marginBottom:10 }}>
-                    {[20,38,28,52,32,68,45,80,42,66,55,88].map((h, i) => (
-                      <div key={i} className="bar" style={{
-                        flex:1, borderRadius: "3px 3px 0 0", height:`${h}%`,
-                        background: i===11
-                          ? `linear-gradient(180deg,${t.accent},${t.accentLt})`
-                          : dark?"rgba(90,158,58,.2)":"rgba(90,158,58,.16)",
-                        "--i":i,
-                      } as React.CSSProperties}/>
-                    ))}
+                    {comparisonPodcasts.length > 0 ? comparisonPodcasts.map((podcast, i) => {
+                      const metricValue = podcast.visibility || podcast.totalClips || 1;
+                      return (
+                        <div key={podcast.podcastId} style={{ flex:1, display:"flex", flexDirection:"column", alignItems:"center", gap:6 }}>
+                          <div className="bar" style={{
+                            width:"100%",
+                            borderRadius: "3px 3px 0 0",
+                            height:`${Math.max(16, Math.round((metricValue / comparisonMax) * 100))}%`,
+                            background: i===0
+                              ? `linear-gradient(180deg,${t.accent},${t.accentLt})`
+                              : dark?"rgba(90,158,58,.2)":"rgba(90,158,58,.16)",
+                            "--i":i,
+                          } as React.CSSProperties}/>
+                          <span style={{ fontSize:10, color:i===0 ? t.accent : t.textFaint }}>
+                            {podcast.title.slice(0, 6)}
+                          </span>
+                        </div>
+                      );
+                    }) : (
+                      <div style={{ color:t.textSub, fontSize:12, lineHeight:1.6 }}>
+                        Upload an episode to see podcast comparisons here.
+                      </div>
+                    )}
                   </div>
                   <div style={{ display:"flex", justifyContent:"space-between" }}>
-                    <span style={{ fontSize:10, color:t.textFaint }}>12 wks ago</span>
-                    <span style={{ fontSize:11, fontWeight:600, color:t.accent }}>This week</span>
+                    <span style={{ fontSize:10, color:t.textFaint }}>
+                      {visibilityTotal > 0 ? "Views + downloads by podcast" : "Clip totals by podcast"}
+                    </span>
+                    <span style={{ fontSize:11, fontWeight:600, color:t.accent }}>
+                      {analytics?.estimated ? "Estimated fallback" : "Live backend metrics"}
+                    </span>
                   </div>
                 </div>
 
-                {/* Free trial card */}
+                {/* Performance summary */}
                 <div style={{
                   padding: "20px", borderRadius: 18,
                   border: `1px solid ${t.border}`,
@@ -979,34 +1046,53 @@ export default function DashboardPage() {
                       <Sparkles size={16} color="#8a5a9e" strokeWidth={1.8}/>
                     </div>
                     <div>
-                      <div style={{ fontSize:12, fontWeight:600, color:t.text }}>Free trial</div>
+                      <div style={{ fontSize:12, fontWeight:600, color:t.text }}>Performance summary</div>
                       <div style={{ fontSize:11, color:t.textSub }}>
-                        {profile?.free_trial_used ? "Already used" : "Available"}
+                        {leadingClip ? `Top clip ${leadingClip.clip_number} from ${leadingClip.podcast_title}` : "No clip ranking yet"}
                       </div>
                     </div>
                     <div style={{ marginLeft:"auto" }}>
                       <div style={{
                         padding:"3px 10px", borderRadius:100,
-                        background: profile?.free_trial_used ? "rgba(180,60,60,.12)" : "rgba(90,158,58,.12)",
-                        border: `1px solid ${profile?.free_trial_used ? "rgba(180,60,60,.25)" : "rgba(90,158,58,.25)"}`,
+                        background: leadingClip ? "rgba(90,158,58,.12)" : "rgba(180,60,60,.12)",
+                        border: `1px solid ${leadingClip ? "rgba(90,158,58,.25)" : "rgba(180,60,60,.25)"}`,
                         fontSize:10, fontWeight:700, letterSpacing:".1em", textTransform:"uppercase",
-                        color: profile?.free_trial_used ? t.red : t.accent,
+                        color: leadingClip ? t.accent : t.red,
                       }}>
-                        {profile?.free_trial_used ? "Used" : "Active"}
+                        {leadingClip ? "Tracked" : "Waiting"}
                       </div>
                     </div>
                   </div>
-                  <div style={{
-                    height:4, borderRadius:2,
-                    background:dark?"rgba(90,158,58,.12)":"rgba(90,158,58,.1)",
-                    overflow:"hidden",
-                  }}>
-                    <div style={{
-                      height:"100%", borderRadius:2,
-                      width: profile?.free_trial_used ? "100%" : "40%",
-                      background:`linear-gradient(90deg,${t.accent},${t.accentLt})`,
-                      transition:"width .8s cubic-bezier(.22,1,.36,1)",
-                    }}/>
+                  <div style={{ display:"grid", gap:10 }}>
+                    <div style={{ fontSize:13, color:t.textSub, lineHeight:1.65 }}>
+                      {leadingClip
+                        ? `${leadingClip.views} views · ${leadingClip.downloads} downloads · ${leadingClip.published ? "published" : "private"}`
+                        : "Generate and publish clips to unlock comparative performance insight."}
+                    </div>
+                    <div style={{ display:"grid", gap:8 }}>
+                      {[
+                        `${done} episode${done === 1 ? "" : "s"} are ready for clips.`,
+                        `${processing} currently processing${payments ? ` · ${payments} waiting on payment` : ""}.`,
+                        analytics?.average_virality_score
+                          ? `Average virality score is ${analytics.average_virality_score.toFixed(1)} across tracked clips.`
+                          : "Virality averages will appear after clips are generated.",
+                      ].map((line) => (
+                        <div
+                          key={line}
+                          style={{
+                            padding:"10px 12px",
+                            borderRadius:12,
+                            border:`1px solid ${t.borderSub}`,
+                            background:dark?"rgba(90,158,58,.05)":"rgba(90,158,58,.04)",
+                            color:t.textSub,
+                            fontSize:12,
+                            lineHeight:1.6,
+                          }}
+                        >
+                          {line}
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </div>
 
@@ -1022,8 +1108,9 @@ export default function DashboardPage() {
                   </div>
                   {[
                     { icon:Plus,    label:"Upload episode",    sub:"Add new content",    href:"/upload" },
-                    { icon:Play,    label:"View clips",        sub:"AI moments",         href:"/clips" },
-                    { icon:Settings,label:"Account settings",  sub:"Profile & billing",  href:"/profile" },
+                    { icon:Library, label:"Browse podcasts",   sub:"Search your library", href:"/podcasts" },
+                    { icon:Play,    label:"View clips",        sub:"Open discovery flow", href:"/clips" },
+                    { icon:BarChart2,label:"View analytics",   sub:"Performance summary", href:"/analytics" },
                   ].map(({ icon:Icon, label, sub, href }) => (
                     <Link key={href} href={href} className="sidebar-link" style={{
                       display:"flex", alignItems:"center", justifyContent:"space-between",
@@ -1173,6 +1260,7 @@ export default function DashboardPage() {
                             analysis={analysisByPodcast[podcast.id]}
                             analysisLoading={Boolean(analysisLoadingByPodcast[podcast.id])}
                             onAnalyze={() => void runAnalysis(podcast.id)}
+                            generatedClipsCount={generatedClipsByPodcastId[podcast.id] ?? 0}
                           />
                         </div>
                       ))}

--- a/frontend/app/podcasts/page.tsx
+++ b/frontend/app/podcasts/page.tsx
@@ -21,9 +21,11 @@ import { useAuth } from "@/context/AuthContext";
 import {
   analyzePodcast,
   getJson,
+  getPodcastAnalytics,
   getPodcastAnalysis,
   type AnalysisSummary,
   type Podcast,
+  type PodcastAnalyticsSummary,
   type PodcastsResponse,
 } from "@/lib/api";
 
@@ -85,6 +87,7 @@ export default function PodcastsPage() {
   const [podcasts, setPodcasts] = useState<Podcast[]>([]);
   const [analysisByPodcast, setAnalysisByPodcast] = useState<Record<string, AnalysisSummary | null>>({});
   const [analysisLoadingByPodcast, setAnalysisLoadingByPodcast] = useState<Record<string, boolean>>({});
+  const [analyticsByPodcastId, setAnalyticsByPodcastId] = useState<Record<string, PodcastAnalyticsSummary>>({});
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<"all" | "processing" | "payments" | "done">("all");
 
@@ -118,8 +121,16 @@ export default function PodcastsPage() {
           return;
         }
 
-        const podcastsResponse = await getJson<PodcastsResponse>("/podcasts", token);
+        const [podcastsResponse, analyticsResponse] = await Promise.all([
+          getJson<PodcastsResponse>("/podcasts", token),
+          getPodcastAnalytics(token).catch(() => null),
+        ]);
         setPodcasts(podcastsResponse.podcasts);
+        setAnalyticsByPodcastId(
+          Object.fromEntries(
+            (analyticsResponse?.podcasts ?? []).map((podcast) => [podcast.podcast_id, podcast]),
+          ) as Record<string, PodcastAnalyticsSummary>,
+        );
 
         const analysisEntries = await Promise.all(
           podcastsResponse.podcasts.map(async (podcast) => {
@@ -156,7 +167,24 @@ export default function PodcastsPage() {
   const filtered = useMemo(() => {
     return podcastsWithStatus.filter((podcast) => {
       const normalizedQuery = query.trim().toLowerCase();
-      const matchesQuery = !normalizedQuery || podcast.title.toLowerCase().includes(normalizedQuery);
+      const analysis = analysisByPodcast[podcast.id];
+      const searchFields = [
+        podcast.title,
+        podcast.status.replaceAll("_", " "),
+        getEffectivePodcastStatus(
+          podcast,
+          analysis,
+          Boolean(analysisLoadingByPodcast[podcast.id]),
+        ).replaceAll("_", " "),
+        fmtDur(podcast.duration || 0),
+        analysis?.total_scored_segments
+          ? `${analysis.total_scored_segments} scored segments ready for clips`
+          : "",
+        analysis?.highest_score ? `peak score ${analysis.highest_score.toFixed(1)}` : "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      const matchesQuery = !normalizedQuery || searchFields.includes(normalizedQuery);
       const matchesFilter =
         filter === "all"
           ? true
@@ -167,11 +195,12 @@ export default function PodcastsPage() {
               : ["done", "completed"].includes(podcast.status);
       return matchesQuery && matchesFilter;
     });
-  }, [filter, podcastsWithStatus, query]);
+  }, [analysisByPodcast, analysisLoadingByPodcast, filter, podcastsWithStatus, query]);
 
   const doneCount = podcastsWithStatus.filter((podcast) => ["done", "completed"].includes(podcast.status)).length;
   const processingCount = podcastsWithStatus.filter((podcast) => ["processing", "queued"].includes(podcast.status)).length;
   const totalDuration = podcasts.reduce((sum, podcast) => sum + (podcast.duration || 0), 0);
+  const hasActiveDiscoveryFilters = query.trim().length > 0 || filter !== "all";
   const strongestPodcast = [...podcastsWithStatus]
     .filter((podcast) => analysisByPodcast[podcast.id]?.highest_score)
     .sort(
@@ -458,13 +487,13 @@ export default function PodcastsPage() {
           <div style={{ borderRadius: 22, background: t.card, border: `1px solid ${t.border}`, padding: 16 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 10, borderRadius: 16, background: t.cardAlt, border: `1px solid ${t.borderSub}`, padding: "12px 14px" }}>
               <Search size={16} color={t.textSub} />
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search podcasts by title"
-                style={{ flex: 1, border: "none", outline: "none", background: "transparent", color: t.text, fontSize: 14 }}
-              />
-            </div>
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search by title, status, duration, or clip readiness"
+                  style={{ flex: 1, border: "none", outline: "none", background: "transparent", color: t.text, fontSize: 14 }}
+                />
+              </div>
           </div>
 
           <div style={{ borderRadius: 22, background: t.card, border: `1px solid ${t.border}`, padding: 10, display: "flex", gap: 8, flexWrap: "wrap" }}>
@@ -521,6 +550,33 @@ export default function PodcastsPage() {
             </div>
           </div>
 
+          {hasActiveDiscoveryFilters ? (
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 16, color: t.textSub, fontSize: 13 }}>
+              <span>
+                {filtered.length} match{filtered.length === 1 ? "" : "es"} for your current discovery view
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  setQuery("");
+                  setFilter("all");
+                }}
+                className="pill-btn"
+                style={{
+                  border: "none",
+                  borderRadius: 999,
+                  padding: "9px 13px",
+                  background: t.cardAlt,
+                  color: t.textSub,
+                  cursor: "pointer",
+                  fontWeight: 700,
+                }}
+              >
+                Clear search
+              </button>
+            </div>
+          ) : null}
+
           {loading || authLoading ? (
             <div style={{ display: "flex", justifyContent: "center", padding: "64px 0", color: t.textSub }}>
               <Loader2 size={24} className="animate-spin" />
@@ -529,7 +585,33 @@ export default function PodcastsPage() {
             <div style={{ borderRadius: 22, border: `1px dashed ${t.border}`, padding: "54px 24px", textAlign: "center", color: t.textSub }}>
               <Clapperboard size={32} style={{ margin: "0 auto 12px" }} />
               <h2 style={{ fontFamily: "'DM Serif Display', serif", fontSize: 28, color: t.text, margin: 0 }}>No podcasts match this view</h2>
-              <p style={{ marginTop: 10, lineHeight: 1.8 }}>Try another filter or upload a new episode to grow your library.</p>
+              <p style={{ marginTop: 10, lineHeight: 1.8 }}>
+                {hasActiveDiscoveryFilters
+                  ? "Try clearing the current search or changing the filter to surface more episodes."
+                  : "Upload a new episode to grow your library."}
+              </p>
+              {hasActiveDiscoveryFilters ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setQuery("");
+                    setFilter("all");
+                  }}
+                  className="pill-btn"
+                  style={{
+                    marginTop: 18,
+                    border: "none",
+                    borderRadius: 999,
+                    padding: "11px 16px",
+                    background: `linear-gradient(135deg, ${t.accent}, ${t.accentLt})`,
+                    color: "#fff",
+                    cursor: "pointer",
+                    fontWeight: 700,
+                  }}
+                >
+                  Reset discovery
+                </button>
+              ) : null}
             </div>
           ) : (
             <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fill, minmax(280px, 1fr))", gap: 16 }}>
@@ -540,6 +622,7 @@ export default function PodcastsPage() {
                   analysis={analysisByPodcast[podcast.id]}
                   analysisLoading={Boolean(analysisLoadingByPodcast[podcast.id])}
                   onAnalyze={() => void runAnalysis(podcast.id)}
+                  generatedClipsCount={analyticsByPodcastId[podcast.id]?.total_clips ?? 0}
                 />
               ))}
             </div>

--- a/frontend/components/PodcastCard.tsx
+++ b/frontend/components/PodcastCard.tsx
@@ -58,12 +58,13 @@ function Ring({ score }: { score: number }) {
 
 /* ════ EXPORT ════ */
 export function PodcastCard({
-  podcast, analysis, analysisLoading = false, onAnalyze,
+  podcast, analysis, analysisLoading = false, onAnalyze, generatedClipsCount = 0,
 }: {
   podcast: Podcast; analysis?: AnalysisSummary | null;
-  analysisLoading?: boolean; onAnalyze?: () => void;
+  analysisLoading?: boolean; onAnalyze?: () => void; generatedClipsCount?: number;
 }) {
   const hasAnalysis  = Boolean(analysis && analysis.total_scored_segments > 0);
+  const hasGeneratedVideos = generatedClipsCount > 0;
   const needsPayment = podcast.status === "awaiting_payment";
   const b            = badge(podcast.status);
   const stages       = STAGES(podcast.duration);
@@ -185,16 +186,22 @@ export function PodcastCard({
             <>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 9 }}>
                 <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
-                  <Ring score={analysis!.highest_score}/>
+                  <Ring score={hasGeneratedVideos ? 100 : analysis!.highest_score}/>
                   <div>
                     <div style={{ fontSize: 12, fontWeight: 700, color: "#1e3418" }}>
-                      {analysis!.highest_score.toFixed(1)} top score
+                      {hasGeneratedVideos
+                        ? "100 video workflow complete"
+                        : `${analysis!.highest_score.toFixed(1)} top score`}
                     </div>
                     <div style={{ fontSize: 10, color: "#7aaa55", marginTop: 1 }}>
-                      {analysis!.total_scored_segments} segments
+                      {hasGeneratedVideos
+                        ? `${generatedClipsCount} generated clip${generatedClipsCount === 1 ? "" : "s"}`
+                        : `${analysis!.total_scored_segments} segments`}
                     </div>
                     <div style={{ fontSize: 10, color: "#526352", marginTop: 4, lineHeight: 1.45 }}>
-                      Analysis finds moments first. Open clips to render the final videos.
+                      {hasGeneratedVideos
+                        ? "Final videos are ready. Open clips to review, publish, or download them."
+                        : "Analysis finds moments first. Open clips to render the final videos."}
                     </div>
                   </div>
                 </div>
@@ -204,7 +211,7 @@ export function PodcastCard({
                     background: "rgba(90,158,58,.1)", border: "1px solid rgba(90,158,58,.2)",
                     fontSize: 9, fontWeight: 700, letterSpacing: ".1em",
                     textTransform: "uppercase", color: "#2f7020", whiteSpace: "nowrap",
-                  }}>Analyzed</span>
+                  }}>{hasGeneratedVideos ? "Rendered" : "Analyzed"}</span>
                   <Link href={`/clips?podcastId=${podcast.id}`} style={{
                     display: "inline-flex", alignItems: "center", gap: 3,
                     padding: "4px 10px", borderRadius: 100,

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -9,6 +9,7 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".next-*/**",
     ".next-build/**",
     ".next-build-webpack/**",
     "out/**",

--- a/frontend/lib/analytics-presentation.tsx
+++ b/frontend/lib/analytics-presentation.tsx
@@ -1,0 +1,411 @@
+import type { CSSProperties } from "react";
+
+import type { PodcastClipMetrics } from "./api";
+
+export type AnalyticsTheme = {
+  card: string;
+  cardAlt: string;
+  border: string;
+  borderSub: string;
+  text: string;
+  textSub: string;
+  textFaint: string;
+  accent: string;
+  chip: string;
+  errorText: string;
+};
+
+export const defaultAnalyticsTheme: AnalyticsTheme = {
+  card: "rgba(13,20,11,.88)",
+  cardAlt: "rgba(16,24,13,.94)",
+  border: "rgba(60,105,40,.34)",
+  borderSub: "rgba(60,105,40,.18)",
+  text: "#dff0d8",
+  textSub: "rgba(163,210,128,.68)",
+  textFaint: "rgba(100,148,72,.42)",
+  accent: "#5a9e3a",
+  chip: "rgba(90,158,58,.12)",
+  errorText: "#efaaaa",
+};
+
+export function formatAnalyticsChange(value: number): string {
+  const prefix = value > 0 ? "+" : "";
+  return `${prefix}${value.toFixed(1)}%`;
+}
+
+export function buildAnalyticsSnapshot(metrics: PodcastClipMetrics | null): {
+  topClip: PodcastClipMetrics["top_clips"][number] | null;
+  totalVisibility: number;
+  publishRate: number;
+  averageViewsPerClip: number;
+} {
+  const topClip = metrics?.top_clips[0] ?? null;
+  const totalVisibility = metrics ? metrics.total_views + metrics.total_downloads : 0;
+  const publishRate =
+    metrics && metrics.total_clips > 0
+      ? Math.round((metrics.published_clips / metrics.total_clips) * 100)
+      : 0;
+  const averageViewsPerClip =
+    metrics && metrics.total_clips > 0
+      ? Math.round(metrics.total_views / metrics.total_clips)
+      : 0;
+
+  return {
+    topClip,
+    totalVisibility,
+    publishRate,
+    averageViewsPerClip,
+  };
+}
+
+type AnalyticsMetricsDisplayProps = {
+  metrics: PodcastClipMetrics | null;
+  loadingMetrics: boolean;
+  isMobile: boolean;
+  theme?: AnalyticsTheme;
+};
+
+export function AnalyticsMetricsDisplay({
+  metrics,
+  loadingMetrics,
+  isMobile,
+  theme = defaultAnalyticsTheme,
+}: AnalyticsMetricsDisplayProps) {
+  const snapshot = buildAnalyticsSnapshot(metrics);
+  const metricCards = metrics
+    ? [
+        { label: "Views", value: metrics.total_views },
+        { label: "Downloads", value: metrics.total_downloads },
+        { label: "Published", value: metrics.published_clips },
+        {
+          label: "Click Trend",
+          value: formatAnalyticsChange(metrics.average_click_trend),
+        },
+      ]
+    : [];
+
+  if (loadingMetrics) {
+    return (
+      <div style={{ display: "grid", gap: 18 }}>
+        <div style={{ color: theme.textSub, lineHeight: 1.8 }}>
+          Loading clip metrics...
+        </div>
+        <div style={{ color: theme.textSub, lineHeight: 1.8 }}>
+          Building the ranking table...
+        </div>
+      </div>
+    );
+  }
+
+  if (!metrics) {
+    return (
+      <div style={{ display: "grid", gap: 18 }}>
+        <div style={{ color: theme.textSub, lineHeight: 1.8 }}>
+          No metrics yet for this podcast. Generate clips first to populate analytics.
+        </div>
+        <div style={{ color: theme.textSub, lineHeight: 1.8 }}>
+          No top clips available yet for this podcast.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 18 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: isMobile ? "1fr" : "repeat(4, 1fr)",
+          gap: 14,
+        }}
+      >
+        {metricCards.map((item) => (
+          <div
+            key={item.label}
+            style={{
+              borderRadius: 18,
+              border: `1px solid ${theme.borderSub}`,
+              background: theme.cardAlt,
+              padding: 16,
+            }}
+          >
+            <div
+              style={{
+                marginTop: 14,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: ".2em",
+                textTransform: "uppercase",
+                color: theme.textFaint,
+              }}
+            >
+              {item.label}
+            </div>
+            <div
+              style={{
+                marginTop: 6,
+                fontSize: 30,
+                fontStyle: "italic",
+              }}
+            >
+              {item.value}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <section
+        style={{
+          display: "grid",
+          gridTemplateColumns: isMobile ? "1fr" : "1fr 1fr",
+          gap: 18,
+        }}
+      >
+        <MetricPanel theme={theme} title="Reach Snapshot">
+          <div style={{ fontSize: 34, lineHeight: 1.04, marginBottom: 8 }}>
+            {snapshot.totalVisibility}
+          </div>
+          <div style={{ color: theme.textSub, lineHeight: 1.75 }}>
+            Combined views and downloads across the selected podcast&apos;s clip set,
+            averaging {snapshot.averageViewsPerClip} views per clip.
+          </div>
+        </MetricPanel>
+
+        <MetricPanel theme={theme} title="Leading Clip">
+          {snapshot.topClip ? (
+            <>
+              <div style={{ fontSize: 30, lineHeight: 1.04 }}>
+                Clip {snapshot.topClip.clip_number}
+              </div>
+              <div style={{ marginTop: 8, color: theme.textSub, lineHeight: 1.75 }}>
+                {snapshot.topClip.title}
+              </div>
+              <div style={{ marginTop: 12, display: "flex", gap: 10, flexWrap: "wrap" }}>
+                <MetricBadge
+                  background={theme.chip}
+                  color={theme.accent}
+                  label={`${snapshot.topClip.views} views`}
+                />
+                <MetricBadge
+                  background={theme.cardAlt}
+                  border={`1px solid ${theme.borderSub}`}
+                  color={theme.textSub}
+                  label={`${snapshot.topClip.downloads} downloads`}
+                />
+                <MetricBadge
+                  background={theme.cardAlt}
+                  border={`1px solid ${theme.borderSub}`}
+                  color={theme.textSub}
+                  label={formatAnalyticsChange(snapshot.topClip.click_trend)}
+                />
+                <MetricBadge
+                  background={theme.cardAlt}
+                  border={`1px solid ${theme.borderSub}`}
+                  color={theme.textSub}
+                  label={`${snapshot.publishRate}% publish rate`}
+                />
+              </div>
+            </>
+          ) : (
+            <div style={{ color: theme.textSub, lineHeight: 1.75 }}>
+              Once metrics are available, the strongest clip will surface here
+              automatically.
+            </div>
+          )}
+        </MetricPanel>
+      </section>
+
+      <section
+        style={{
+          borderRadius: 24,
+          background: theme.card,
+          border: `1px solid ${theme.border}`,
+          padding: 20,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            gap: 12,
+            flexWrap: "wrap",
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                letterSpacing: ".2em",
+                textTransform: "uppercase",
+                color: theme.textFaint,
+                marginBottom: 6,
+              }}
+            >
+              Top Clips Table
+            </div>
+            <h3 style={{ margin: 0, fontSize: 30, lineHeight: 1.05 }}>
+              Views, downloads, and click trends
+            </h3>
+          </div>
+          {metrics.estimated ? (
+            <div
+              style={{
+                borderRadius: 999,
+                padding: "10px 14px",
+                background: theme.cardAlt,
+                border: `1px solid ${theme.borderSub}`,
+                color: theme.textSub,
+                fontSize: 13,
+                fontWeight: 600,
+              }}
+            >
+              Estimated metrics
+            </div>
+          ) : null}
+        </div>
+
+        {metrics.top_clips.length === 0 ? (
+          <div style={{ color: theme.textSub, lineHeight: 1.8 }}>
+            No top clips available yet for this podcast.
+          </div>
+        ) : (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 720 }}>
+              <thead>
+                <tr
+                  style={{
+                    textAlign: "left",
+                    color: theme.textFaint,
+                    fontSize: 11,
+                    letterSpacing: ".18em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  <th style={{ padding: "0 0 12px" }}>Clip</th>
+                  <th style={{ padding: "0 0 12px" }}>Views</th>
+                  <th style={{ padding: "0 0 12px" }}>Downloads</th>
+                  <th style={{ padding: "0 0 12px" }}>Click Trend</th>
+                  <th style={{ padding: "0 0 12px" }}>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {metrics.top_clips.map((clip) => (
+                  <tr
+                    key={clip.clip_id}
+                    style={{ borderTop: `1px solid ${theme.borderSub}` }}
+                  >
+                    <td style={{ padding: "14px 0", verticalAlign: "top" }}>
+                      <div style={{ fontWeight: 700 }}>Clip {clip.clip_number}</div>
+                      <div
+                        style={{
+                          marginTop: 4,
+                          color: theme.textSub,
+                          lineHeight: 1.65,
+                        }}
+                      >
+                        {clip.title}
+                      </div>
+                    </td>
+                    <td style={{ padding: "14px 0", fontWeight: 700 }}>{clip.views}</td>
+                    <td style={{ padding: "14px 0", fontWeight: 700 }}>
+                      {clip.downloads}
+                    </td>
+                    <td
+                      style={{
+                        padding: "14px 0",
+                        fontWeight: 700,
+                        color:
+                          clip.click_trend >= 0 ? theme.accent : theme.errorText,
+                      }}
+                    >
+                      {formatAnalyticsChange(clip.click_trend)}
+                    </td>
+                    <td style={{ padding: "14px 0" }}>
+                      <span
+                        style={{
+                          borderRadius: 999,
+                          padding: "7px 10px",
+                          background: clip.published ? theme.chip : theme.cardAlt,
+                          border: `1px solid ${
+                            clip.published ? theme.accent : theme.borderSub
+                          }`,
+                          color: clip.published ? theme.accent : theme.textSub,
+                          fontWeight: 700,
+                          fontSize: 12,
+                        }}
+                      >
+                        {clip.published ? "Published" : "Private"}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function MetricPanel({
+  children,
+  theme,
+  title,
+}: {
+  children: React.ReactNode;
+  theme: AnalyticsTheme;
+  title: string;
+}) {
+  return (
+    <div
+      style={{
+        borderRadius: 24,
+        background: theme.card,
+        border: `1px solid ${theme.border}`,
+        padding: 20,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          letterSpacing: ".2em",
+          textTransform: "uppercase",
+          color: theme.textFaint,
+          marginBottom: 12,
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function MetricBadge({
+  background,
+  border,
+  color,
+  label,
+}: {
+  background: string;
+  border?: string;
+  color: string;
+  label: string;
+}) {
+  const style: CSSProperties = {
+    borderRadius: 999,
+    padding: "7px 10px",
+    background,
+    color,
+    fontWeight: 700,
+  };
+
+  if (border) {
+    style.border = border;
+  }
+
+  return <span style={style}>{label}</span>;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,6 @@
 import {
   buildDiscoveryItem,
+  buildEstimatedMetricRow,
   buildEstimatedPodcastMetrics,
   filterDiscoveryItems,
   rankRecommendedItems,
@@ -296,6 +297,48 @@ export type ClipRecommendationsResponse = {
 
 export type PodcastClipMetrics = PodcastMetricSummary & {
   top_clips: ClipMetricRow[];
+};
+
+export type TopPerformingClip = {
+  clip_id: string;
+  podcast_id: string;
+  podcast_title: string;
+  clip_number: number;
+  virality_score: number;
+  views: number;
+  downloads: number;
+  published: boolean;
+  published_at?: string | null;
+  estimated?: boolean;
+};
+
+export type PodcastAnalyticsSummary = {
+  podcast_id: string;
+  title: string;
+  status: string;
+  duration: number;
+  total_clips: number;
+  published_clips: number;
+  total_views: number;
+  total_downloads: number;
+  average_virality_score: number;
+  latest_published_at?: string | null;
+  estimated?: boolean;
+};
+
+export type UserPodcastAnalytics = {
+  user_id: string;
+  total_podcasts: number;
+  total_clips: number;
+  published_clips: number;
+  private_clips: number;
+  total_views: number;
+  total_downloads: number;
+  average_virality_score: number;
+  publish_rate: number;
+  top_clips: TopPerformingClip[];
+  podcasts: PodcastAnalyticsSummary[];
+  estimated?: boolean;
 };
 
 type RequestOptions = {
@@ -721,6 +764,135 @@ export async function getRecommendations(
       recommendations: rankRecommendedItems(discoveryItems, 4),
       estimated: true,
     };
+  }
+}
+
+export function buildEstimatedUserAnalytics(
+  userId: string,
+  podcasts: Podcast[],
+  clipsByPodcastId: Record<string, ClipResult[]>,
+): UserPodcastAnalytics {
+  const summaries = podcasts.map((podcast) => {
+    const clips = clipsByPodcastId[podcast.id] ?? [];
+    const metrics = buildEstimatedPodcastMetrics(podcast, clips);
+    const averageViralityScore =
+      clips.length > 0
+        ? Number(
+            (
+              clips.reduce((sum, clip) => sum + clip.virality_score, 0) / clips.length
+            ).toFixed(2),
+          )
+        : 0;
+    const latestPublishedAt = clips
+      .filter((clip) => clip.published && clip.published_at)
+      .map((clip) => clip.published_at ?? null)
+      .sort()
+      .at(-1) ?? null;
+
+    return {
+      podcast_id: podcast.id,
+      title: podcast.title,
+      status: podcast.status,
+      duration: podcast.duration,
+      total_clips: metrics.total_clips,
+      published_clips: metrics.published_clips,
+      total_views: metrics.total_views,
+      total_downloads: metrics.total_downloads,
+      average_virality_score: averageViralityScore,
+      latest_published_at: latestPublishedAt,
+      estimated: true,
+    };
+  });
+
+  const allTopClips = podcasts
+    .flatMap((podcast) =>
+      (clipsByPodcastId[podcast.id] ?? []).map((clip) => {
+        const metrics = buildEstimatedMetricRow(clip);
+        return {
+          clip_id: clip.id,
+          podcast_id: podcast.id,
+          podcast_title: podcast.title,
+          clip_number: clip.clip_number,
+          virality_score: clip.virality_score,
+          views: metrics.views,
+          downloads: metrics.downloads,
+          published: Boolean(clip.published),
+          published_at: clip.published_at ?? null,
+          estimated: true,
+        };
+      }),
+    )
+    .sort((left, right) => {
+      if (right.views !== left.views) {
+        return right.views - left.views;
+      }
+      if (right.downloads !== left.downloads) {
+        return right.downloads - left.downloads;
+      }
+      if (right.virality_score !== left.virality_score) {
+        return right.virality_score - left.virality_score;
+      }
+      return left.clip_number - right.clip_number;
+    })
+    .slice(0, 5);
+
+  const totalClips = summaries.reduce((sum, item) => sum + item.total_clips, 0);
+  const publishedClips = summaries.reduce((sum, item) => sum + item.published_clips, 0);
+  const totalViews = summaries.reduce((sum, item) => sum + item.total_views, 0);
+  const totalDownloads = summaries.reduce((sum, item) => sum + item.total_downloads, 0);
+  const viralityScores = Object.values(clipsByPodcastId).flatMap((clips) =>
+    clips.map((clip) => clip.virality_score),
+  );
+
+  return {
+    user_id: userId.trim() || podcasts[0]?.user_id || "current-user",
+    total_podcasts: podcasts.length,
+    total_clips: totalClips,
+    published_clips: publishedClips,
+    private_clips: Math.max(0, totalClips - publishedClips),
+    total_views: totalViews,
+    total_downloads: totalDownloads,
+    average_virality_score:
+      viralityScores.length > 0
+        ? Number(
+            (
+              viralityScores.reduce((sum, score) => sum + score, 0) /
+              viralityScores.length
+            ).toFixed(2),
+          )
+        : 0,
+    publish_rate: totalClips
+      ? Number(((publishedClips / totalClips) * 100).toFixed(2))
+      : 0,
+    top_clips: allTopClips,
+    podcasts: summaries,
+    estimated: true,
+  };
+}
+
+export async function getPodcastAnalytics(
+  token?: string | null,
+): Promise<UserPodcastAnalytics> {
+  try {
+    return await getJson<UserPodcastAnalytics>("/podcasts/analytics", token);
+  } catch {
+    const podcastsResponse = await getJson<PodcastsResponse>("/podcasts", token);
+    const clipEntries = await Promise.all(
+      podcastsResponse.podcasts.map(async (podcast) => {
+        try {
+          const result = await getClips(podcast.id, token);
+          return [podcast.id, result.clips] as const;
+        } catch {
+          return [podcast.id, []] as const;
+        }
+      }),
+    );
+
+    return buildEstimatedUserAnalytics(
+      podcastsResponse.podcasts[0]?.user_id ?? "current-user",
+      podcastsResponse.podcasts,
+      Object.fromEntries(clipEntries),
+    );
   }
 }
 

--- a/frontend/tests/analytics.test.tsx
+++ b/frontend/tests/analytics.test.tsx
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
 
+import { buildEstimatedUserAnalytics, type PodcastClipMetrics } from "../lib/api";
+import {
+  AnalyticsMetricsDisplay,
+  buildAnalyticsSnapshot,
+  defaultAnalyticsTheme,
+} from "../lib/analytics-presentation";
 import {
   buildEstimatedMetricRow,
   buildEstimatedPodcastMetrics,
@@ -8,6 +15,11 @@ import {
 const podcast = {
   id: "pod-9",
   title: "Insight Weekly",
+  user_id: "user-1",
+  duration: 1600,
+  status: "done",
+  created_at: null,
+  updated_at: null,
 };
 
 const clips = [
@@ -18,6 +30,7 @@ const clips = [
     clip_end_seconds: 22,
     duration_seconds: 22,
     virality_score: 88,
+    video_url: "https://example.com/clip-a.mp4",
     subtitle_text: "The audience clicked because the hook landed instantly",
     status: "ready" as const,
     published: true,
@@ -30,6 +43,7 @@ const clips = [
     clip_end_seconds: 48,
     duration_seconds: 23,
     virality_score: 74,
+    video_url: "https://example.com/clip-b.mp4",
     subtitle_text: "This clip is still private but has strong upside",
     status: "ready" as const,
     published: false,
@@ -41,6 +55,7 @@ const clips = [
     clip_end_seconds: 76,
     duration_seconds: 26,
     virality_score: 93,
+    video_url: "https://example.com/clip-c.mp4",
     subtitle_text: "A breakout moment with a strong download profile",
     status: "ready" as const,
     published: true,
@@ -64,4 +79,64 @@ export function runAnalyticsTests(): void {
   assert.equal(metrics.top_clips[0]?.clip_id, "clip-c");
   assert.ok(metrics.average_click_trend > 0);
   assert.equal(metrics.estimated, true);
+
+  const overview = buildEstimatedUserAnalytics("user-1", [podcast], { "pod-9": clips });
+
+  assert.equal(overview.user_id, "user-1");
+  assert.equal(overview.total_podcasts, 1);
+  assert.equal(overview.total_clips, 3);
+  assert.equal(overview.published_clips, 2);
+  assert.equal(overview.private_clips, 1);
+  assert.ok(overview.publish_rate > 60);
+  assert.equal(overview.top_clips[0]?.clip_id, "clip-c");
+  assert.equal(overview.podcasts[0]?.podcast_id, "pod-9");
+  assert.equal(overview.estimated, true);
+
+  const snapshot = buildAnalyticsSnapshot(metrics);
+
+  assert.equal(snapshot.totalVisibility, metrics.total_views + metrics.total_downloads);
+  assert.equal(snapshot.publishRate, 67);
+  assert.equal(snapshot.averageViewsPerClip, Math.round(metrics.total_views / metrics.total_clips));
+  assert.equal(snapshot.topClip?.clip_id, "clip-c");
+
+  const metricsMarkup = renderToStaticMarkup(
+    <AnalyticsMetricsDisplay
+      isMobile={false}
+      loadingMetrics={false}
+      metrics={metrics as PodcastClipMetrics}
+      theme={defaultAnalyticsTheme}
+    />,
+  );
+
+  assert.match(metricsMarkup, /Views/);
+  assert.match(metricsMarkup, /Downloads/);
+  assert.match(metricsMarkup, /Leading Clip/);
+  assert.match(metricsMarkup, /Clip 3/);
+  assert.match(metricsMarkup, /A breakout moment with a strong download profile/);
+  assert.match(metricsMarkup, /Top Clips Table/);
+  assert.match(metricsMarkup, /Published/);
+
+  const emptyMarkup = renderToStaticMarkup(
+    <AnalyticsMetricsDisplay
+      isMobile={false}
+      loadingMetrics={false}
+      metrics={null}
+      theme={defaultAnalyticsTheme}
+    />,
+  );
+
+  assert.match(emptyMarkup, /No metrics yet for this podcast/);
+  assert.match(emptyMarkup, /No top clips available yet for this podcast/);
+
+  const loadingMarkup = renderToStaticMarkup(
+    <AnalyticsMetricsDisplay
+      isMobile={false}
+      loadingMetrics={true}
+      metrics={null}
+      theme={defaultAnalyticsTheme}
+    />,
+  );
+
+  assert.match(loadingMarkup, /Loading clip metrics/);
+  assert.match(loadingMarkup, /Building the ranking table/);
 }

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildAuthenticatedBackendUrl,
   getClipMetrics,
+  getPodcastAnalytics,
   getUserExportSettings,
   getUserProfile,
   getRecommendations,
@@ -54,11 +55,14 @@ export async function runApiTests(): Promise<void> {
   await testGetUserExportSettingsUsesProtectedEndpoint();
   await testUpdateUserExportSettingsPersistsPreferences();
   await testPrepareUploadPostsExportSettings();
+  await testGetPodcastAnalyticsUsesBackendRoute();
   await testSearchClipsUsesBackendDiscoveryRoute();
   await testSearchClipsFallsBackToCurrentClipData();
   await testPublishClipsPostsPublicationPayload();
   await testRevokeClipDownloadPostsRevocationRequest();
   await testRecommendationsFallbackProducesEstimatedResults();
+  await testPodcastAnalyticsFallbackProducesEstimatedSummary();
+  await testGetClipMetricsUsesBackendMetricsRoute();
   await testMetricsFallbackProducesEstimatedSummary();
 }
 
@@ -478,6 +482,83 @@ async function testPrepareUploadPostsExportSettings(): Promise<void> {
   }
 }
 
+async function testGetPodcastAnalyticsUsesBackendRoute(): Promise<void> {
+  const { calls, restore } = withMockFetch(async (url) => {
+    if (url.endsWith("/podcasts/analytics")) {
+      return jsonResponse({
+        user_id: "user-1",
+        total_podcasts: 2,
+        total_clips: 6,
+        published_clips: 4,
+        private_clips: 2,
+        total_views: 940,
+        total_downloads: 180,
+        average_virality_score: 84.5,
+        publish_rate: 66.67,
+        top_clips: [
+          {
+            clip_id: "clip-9",
+            podcast_id: "pod-1",
+            podcast_title: "Growth Lab",
+            clip_number: 3,
+            virality_score: 94,
+            views: 340,
+            downloads: 68,
+            published: true,
+            published_at: "2026-04-24T08:30:00Z",
+          },
+        ],
+        podcasts: [
+          {
+            podcast_id: "pod-1",
+            title: "Growth Lab",
+            status: "done",
+            duration: 1800,
+            total_clips: 4,
+            published_clips: 3,
+            total_views: 640,
+            total_downloads: 132,
+            average_virality_score: 88.2,
+            latest_published_at: "2026-04-24T08:30:00Z",
+          },
+          {
+            podcast_id: "pod-2",
+            title: "Creator Office Hours",
+            status: "processing",
+            duration: 1200,
+            total_clips: 2,
+            published_clips: 1,
+            total_views: 300,
+            total_downloads: 48,
+            average_virality_score: 76.8,
+            latest_published_at: "2026-04-23T11:15:00Z",
+          },
+        ],
+      });
+    }
+
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  try {
+    const result = await getPodcastAnalytics("token-123");
+
+    assert.equal(result.user_id, "user-1");
+    assert.equal(result.total_podcasts, 2);
+    assert.equal(result.total_views, 940);
+    assert.equal(result.top_clips[0]?.clip_id, "clip-9");
+    assert.equal(result.podcasts[1]?.podcast_id, "pod-2");
+    assert.equal(result.estimated, undefined);
+    assert.equal(calls[0]?.init?.method, "GET");
+    assert.equal(
+      (calls[0]?.init?.headers as Record<string, string>)?.Authorization,
+      "Bearer token-123",
+    );
+  } finally {
+    restore();
+  }
+}
+
 async function testSearchClipsUsesBackendDiscoveryRoute(): Promise<void> {
   const { calls, restore } = withMockFetch(async (url) => {
     if (url.includes("/clips/search?")) {
@@ -761,6 +842,146 @@ async function testRecommendationsFallbackProducesEstimatedResults(): Promise<vo
     assert.equal(result.recommendations.length, 3);
     assert.equal(result.recommendations[0]?.id, "clip-1");
     assert.equal(result.recommendations[0]?.recommendation_reason, "Highest upside right now");
+  } finally {
+    restore();
+  }
+}
+
+async function testPodcastAnalyticsFallbackProducesEstimatedSummary(): Promise<void> {
+  const { restore } = withMockFetch(async (url) => {
+    if (url.endsWith("/podcasts/analytics")) {
+      return jsonResponse({ detail: "analytics unavailable" }, 503);
+    }
+    if (url.endsWith("/podcasts")) {
+      return jsonResponse({
+        podcasts: [
+          { id: "pod-1", title: "Growth Lab", user_id: "user-1", duration: 1200, status: "done", created_at: null, updated_at: null },
+          { id: "pod-2", title: "Creator Office Hours", user_id: "user-1", duration: 1800, status: "processing", created_at: null, updated_at: null },
+        ],
+        is_mock: false,
+      });
+    }
+    if (url.endsWith("/podcasts/pod-1/clips")) {
+      return jsonResponse({
+        podcast_id: "pod-1",
+        total_clips_generated: 2,
+        processing_time_seconds: 0,
+        download_folder_url: "/podcasts/pod-1/clips",
+        clips: [
+          {
+            id: "clip-1",
+            clip_number: 1,
+            clip_start_seconds: 0,
+            clip_end_seconds: 20,
+            duration_seconds: 20,
+            virality_score: 91,
+            video_url: "https://example.com/clip-1.mp4",
+            subtitle_text: "High-upside private clip",
+            status: "ready",
+            published: false,
+          },
+          {
+            id: "clip-2",
+            clip_number: 2,
+            clip_start_seconds: 24,
+            clip_end_seconds: 50,
+            duration_seconds: 26,
+            virality_score: 93,
+            video_url: "https://example.com/clip-2.mp4",
+            subtitle_text: "Published winner",
+            status: "ready",
+            published: true,
+            published_at: "2026-04-22T08:00:00Z",
+          },
+        ],
+      });
+    }
+    if (url.endsWith("/podcasts/pod-2/clips")) {
+      return jsonResponse({
+        podcast_id: "pod-2",
+        total_clips_generated: 1,
+        processing_time_seconds: 0,
+        download_folder_url: "/podcasts/pod-2/clips",
+        clips: [
+          {
+            id: "clip-3",
+            clip_number: 1,
+            clip_start_seconds: 0,
+            clip_end_seconds: 18,
+            duration_seconds: 18,
+            virality_score: 74,
+            video_url: "https://example.com/clip-3.mp4",
+            subtitle_text: "Processing episode teaser",
+            status: "processing",
+            published: false,
+          },
+        ],
+      });
+    }
+
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  try {
+    const result = await getPodcastAnalytics("token-123");
+
+    assert.equal(result.estimated, true);
+    assert.equal(result.total_podcasts, 2);
+    assert.equal(result.total_clips, 3);
+    assert.equal(result.published_clips, 1);
+    assert.equal(result.private_clips, 2);
+    assert.equal(result.top_clips[0]?.podcast_id, "pod-1");
+    assert.equal(result.podcasts[0]?.estimated, true);
+  } finally {
+    restore();
+  }
+}
+
+async function testGetClipMetricsUsesBackendMetricsRoute(): Promise<void> {
+  const { calls, restore } = withMockFetch(async (url) => {
+    if (url.endsWith("/podcasts/pod-9/metrics")) {
+      return jsonResponse({
+        podcast_id: "pod-9",
+        podcast_title: "Insight Weekly",
+        total_clips: 3,
+        published_clips: 2,
+        unpublished_clips: 1,
+        total_views: 1180,
+        total_downloads: 204,
+        average_click_trend: 9.4,
+        top_clips: [
+          {
+            clip_id: "clip-a",
+            clip_number: 1,
+            title: "Published clip with strong reach",
+            views: 470,
+            downloads: 82,
+            click_trend: 11.2,
+            published: true,
+            published_at: "2026-04-22T10:00:00Z",
+            virality_score: 88,
+            estimated: false,
+          },
+        ],
+      });
+    }
+
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  try {
+    const result = await getClipMetrics("pod-9", "token-123");
+
+    assert.equal(result.total_clips, 3);
+    assert.equal(result.total_downloads, 204);
+    assert.equal(result.top_clips[0]?.clip_id, "clip-a");
+    assert.equal(result.top_clips[0]?.estimated, false);
+    assert.equal(result.estimated, undefined);
+    assert.equal(calls[0]?.init?.method, "GET");
+    assert.equal(
+      (calls[0]?.init?.headers as Record<string, string>)?.Authorization,
+      "Bearer token-123",
+    );
   } finally {
     restore();
   }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -15,7 +15,8 @@
   "include": [
     "tests/**/*.ts",
     "tests/**/*.tsx",
-    "lib/**/*.ts"
+    "lib/**/*.ts",
+    "lib/**/*.tsx"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Sprint 10 analytics dashboard and discovery polish
## Summary

This PR completes the Sprint 10 frontend work for analytics, discovery UX, and final demo polish.

## What changed

- Completed the analytics dashboard using backend-driven metrics
- Added top clip ranking, reach summaries, trend cards, and clearer analytics states
- Improved clip discovery flow with search, filters, recommendation display, and publish/download actions
- Improved podcast library discovery with better search/filter behavior and stronger empty/loading/error states
- Polished the dashboard overview with analytics summaries, comparisons, notifications, and cleaner navigation paths
- Updated podcast cards so analyzed episodes show `100` once clips/videos have been generated, instead of staying on the raw analysis score
- Extracted analytics presentation logic into a reusable/testable helper component
- Expanded frontend API support for analytics, clip metrics, clip search, and recommendations, including fallback behavior when dedicated endpoints are unavailable
- Added stronger frontend test coverage for analytics rendering and API integration/fallback behavior
- Hardened the backend clip download route to handle stale browser byte-range requests more safely for regenerated local files

## Files changed

### Frontend pages
- `frontend/app/analytics/page.tsx`
  - wired analytics page to real backend metrics
  - added selected podcast metrics, leading clip, reach snapshot, and top clips table
  - improved loading, empty, error, and estimated-metrics states

- `frontend/app/dashboard/page.tsx`
  - integrated analytics overview into the dashboard
  - added podcast comparison summaries, performance summary, and quick actions
  - passed generated clip counts into podcast cards so rendered podcasts surface as complete

- `frontend/app/podcasts/page.tsx`
  - improved library search and filter flow
  - added analytics-aware podcast card state
  - improved discovery and reset behavior

- `frontend/app/clips/page.tsx`
  - improved search/discovery flow for clips
  - added recommendations handling, fallback messaging, and clearer state transitions
  - polished publish, revoke, and download actions

### Frontend components and helpers
- `frontend/components/PodcastCard.tsx`
  - updated analysis card behavior
  - shows `100` and `Rendered` when clips/videos already exist
  - keeps analysis score for podcasts that are analyzed but not yet rendered

- `frontend/lib/analytics-presentation.tsx`
  - new helper for analytics snapshot/presentation rendering
  - made analytics UI logic more reusable and directly testable

- `frontend/lib/api.ts`
  - added/updated support for:
    - podcast analytics
    - clip metrics
    - clip search
    - podcast recommendations
  - included fallback logic when dedicated backend endpoints are unavailable

### Tests
- `frontend/tests/analytics.test.tsx`
  - added analytics rendering and state coverage
  - added snapshot/helper checks for metrics presentation

- `frontend/tests/api.test.ts`
  - added API integration coverage for analytics, metrics, search, recommendations, and fallback behavior

- `frontend/tsconfig.test.json`
  - updated test config so `.tsx` helper modules are included in test compilation

### Tooling / config
- `frontend/.gitignore`
- `frontend/eslint.config.mjs`
  - added support for alternate `.next-*` build folders/ignores

### Backend
- `backend/app/routers/podcasts.py`
  - improved clip download/preview handling for stale byte-range requests on local files
## Why
These changes make the Sprint 10 demo flow more complete and more consistent across dashboard, podcasts, clips, and analytics pages. The result is a clearer analytics story, smoother discovery workflow, and better handling of empty/loading/error/fallback states.
