### PR TITLE
Implement Sprint 11 generation settings backend

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,7 +10,14 @@ from app.models.clip_insights import (
     PodcastClipMetrics,
     RankingFactor,
 )
-from app.models.export_settings import AudioEnhancementSettings, ExportSettings, ExportSettingsInput, SubtitleStyle
+from app.models.export_settings import (
+    AudioEnhancementSettings,
+    ExportSettings,
+    ExportSettingsInput,
+    GenerationSettings,
+    GenerationSettingsInput,
+    SubtitleStyle,
+)
 from app.models.media import MediaInspectionResult
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.publishing import (
@@ -56,6 +63,8 @@ __all__ = [
     "ClipSearchResponse",
     "ExportSettings",
     "ExportSettingsInput",
+    "GenerationSettings",
+    "GenerationSettingsInput",
     "GenerateClipsRequest",
     "MediaInspectionResult",
     "OverlayDecision",

--- a/backend/app/models/clipping.py
+++ b/backend/app/models/clipping.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.models.analysis import ScoreSegment
-from app.models.export_settings import ExportSettings, ExportSettingsInput
+from app.models.export_settings import (
+    ExportSettings,
+    ExportSettingsInput,
+    GenerationSettings,
+    GenerationSettingsInput,
+)
 from app.models.overlay import OverlayDecision
 from app.models.transcription import TranscriptionResult
 
@@ -28,14 +33,20 @@ class ClipResult(BaseModel):
     published_at: datetime | None = None
     overlay: OverlayDecision | None = None
     export_settings: ExportSettings = Field(default_factory=ExportSettings)
+    generation_settings: GenerationSettings = Field(default_factory=GenerationSettings)
 
-    @field_validator("id", "video_url", "subtitle_text")
+    @field_validator("id", "video_url")
     @classmethod
     def validate_required_strings(cls, value: str) -> str:
         cleaned = " ".join(value.split()) if value.strip() else value.strip()
         if not cleaned:
             raise ValueError("Field cannot be empty.")
         return cleaned
+
+    @field_validator("subtitle_text")
+    @classmethod
+    def normalize_subtitle_text(cls, value: str) -> str:
+        return " ".join(value.split()) if value.strip() else ""
 
 
 class ClipGenerationResult(BaseModel):
@@ -47,6 +58,7 @@ class ClipGenerationResult(BaseModel):
     processing_time_seconds: float = Field(ge=0)
     download_folder_url: str
     export_settings: ExportSettings = Field(default_factory=ExportSettings)
+    generation_settings: GenerationSettings = Field(default_factory=GenerationSettings)
 
     @field_validator("podcast_id", "download_folder_url")
     @classmethod
@@ -63,4 +75,47 @@ class GenerateClipsRequest(BaseModel):
     score_segments: list[ScoreSegment] | None = None
     transcription: TranscriptionResult | None = None
     export_settings: ExportSettingsInput | None = None
+    generation_settings: GenerationSettingsInput | None = None
+    clip_duration_seconds: int | None = Field(default=None, ge=8, le=90)
+    number_of_clips: int | None = Field(default=None, ge=1, le=10)
+    topic_focus: str | None = Field(default=None, max_length=120)
+    subtitles_enabled: bool | None = None
+    save_generation_settings: bool = False
+    use_preferred_generation_settings: bool = False
+
+    @field_validator("topic_focus")
+    @classmethod
+    def normalize_topic_focus(cls, value: str | None) -> str | None:
+        return GenerationSettings.normalize_topic_focus(value)
+
+    @model_validator(mode="after")
+    def validate_generation_payload(self) -> "GenerateClipsRequest":
+        if self.save_generation_settings and self.generation_settings is None and not self._has_direct_generation_fields():
+            raise ValueError("save_generation_settings requires at least one generation setting.")
+        return self
+
+    def resolve_generation_settings(self, preferred: GenerationSettings | None = None) -> GenerationSettings:
+        resolved = self.generation_settings.resolve(preferred) if self.generation_settings else (preferred or GenerationSettings())
+        direct_updates = {
+            key: value
+            for key, value in {
+                "clip_duration_seconds": self.clip_duration_seconds,
+                "number_of_clips": self.number_of_clips,
+                "topic_focus": self.topic_focus,
+                "subtitles_enabled": self.subtitles_enabled,
+            }.items()
+            if value is not None
+        }
+        return resolved.model_copy(update=direct_updates)
+
+    def _has_direct_generation_fields(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.clip_duration_seconds,
+                self.number_of_clips,
+                self.topic_focus,
+                self.subtitles_enabled,
+            )
+        )
 

--- a/backend/app/models/export_settings.py
+++ b/backend/app/models/export_settings.py
@@ -154,6 +154,56 @@ class AudioEnhancementSettings(BaseModel):
         return self
 
 
+class GenerationSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_duration_seconds: int = Field(default=30, ge=8, le=90)
+    number_of_clips: int = Field(default=5, ge=1, le=10)
+    topic_focus: str | None = Field(default=None, max_length=120)
+    subtitles_enabled: bool = True
+
+    @field_validator("topic_focus")
+    @classmethod
+    def normalize_topic_focus(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = " ".join(value.split())
+        if not cleaned:
+            return None
+        if not re.fullmatch(r"[A-Za-z0-9\s,.'\-#/&]+", cleaned):
+            raise ValueError("topic_focus can only contain letters, numbers, spaces, and simple punctuation.")
+        return cleaned
+
+
+class GenerationSettingsInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_duration_seconds: int | None = Field(default=None, ge=8, le=90)
+    number_of_clips: int | None = Field(default=None, ge=1, le=10)
+    topic_focus: str | None = Field(default=None, max_length=120)
+    subtitles_enabled: bool | None = None
+
+    @field_validator("topic_focus")
+    @classmethod
+    def normalize_topic_focus(cls, value: str | None) -> str | None:
+        return GenerationSettings.normalize_topic_focus(value)
+
+    def resolve(self, base: GenerationSettings | None = None) -> GenerationSettings:
+        resolved_base = base or GenerationSettings()
+        return resolved_base.model_copy(
+            update={
+                key: value
+                for key, value in {
+                    "clip_duration_seconds": self.clip_duration_seconds,
+                    "number_of_clips": self.number_of_clips,
+                    "topic_focus": self.topic_focus,
+                    "subtitles_enabled": self.subtitles_enabled,
+                }.items()
+                if value is not None
+            }
+        )
+
+
 class ExportSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -165,6 +215,7 @@ class ExportSettings(BaseModel):
     face_tracking_enabled: bool = False
     subtitle_style: SubtitleStyle = Field(default_factory=SubtitleStyle)
     audio_enhancement: AudioEnhancementSettings = Field(default_factory=AudioEnhancementSettings)
+    generation_settings: GenerationSettings = Field(default_factory=GenerationSettings)
 
     @model_validator(mode="after")
     def validate_export_preferences(self) -> "ExportSettings":
@@ -200,6 +251,7 @@ class ExportSettingsInput(BaseModel):
     face_tracking_enabled: bool = False
     subtitle_style: SubtitleStyle | None = None
     audio_enhancement: AudioEnhancementSettings | None = None
+    generation_settings: GenerationSettingsInput | None = None
 
     @model_validator(mode="after")
     def validate_request_preferences(self) -> "ExportSettingsInput":
@@ -235,4 +287,9 @@ class ExportSettingsInput(BaseModel):
             face_tracking_enabled=self.face_tracking_enabled,
             subtitle_style=self.subtitle_style or SubtitleStyle(),
             audio_enhancement=self.audio_enhancement or AudioEnhancementSettings(),
+            generation_settings=(
+                self.generation_settings.resolve()
+                if self.generation_settings is not None
+                else GenerationSettings()
+            ),
         )

--- a/backend/app/routers/clips.py
+++ b/backend/app/routers/clips.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.dependencies.auth import AuthenticatedUser, get_current_user
+from app.models.export_settings import GenerationSettings
 from app.models.publishing import (
     ClipMetricResponse,
     ClipPublicationStatus,
@@ -23,6 +24,13 @@ from app.services.publishing_service import (
 )
 
 router = APIRouter(prefix="/clips", tags=["clips"])
+
+
+@router.get("/generation-settings/defaults", response_model=GenerationSettings)
+async def get_generation_settings_defaults(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> GenerationSettings:
+    return GenerationSettings()
 
 
 @router.get("/search", response_model=ClipSearchResult)

--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -43,6 +43,7 @@ from app.services.publishing_service import (
 )
 from app.services.recommendation_service import RecommendationServiceError, recommend_clips
 from app.services.profile_service import get_profile_for_analytics
+from app.services.profile_service import get_user_export_settings, update_user_export_settings
 from app.services.podcast_service import (
     get_podcasts_for_user,
     get_user_podcast_analytics,
@@ -211,11 +212,40 @@ async def generate_podcast_clips(
             detail="Podcast not found for the current user.",
         )
 
+    preferred_export_settings = (
+        get_user_export_settings(current_user.id)
+        if payload.use_preferred_generation_settings or payload.save_generation_settings
+        else None
+    )
+    if payload.save_generation_settings and preferred_export_settings is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found for the current user.",
+        )
+    preferred_generation_settings = (
+        preferred_export_settings.export_settings.generation_settings
+        if payload.use_preferred_generation_settings and preferred_export_settings is not None
+        else None
+    )
+    generation_settings = payload.resolve_generation_settings(preferred_generation_settings)
+    if payload.save_generation_settings and preferred_export_settings is not None:
+        update_user_export_settings(
+            current_user.id,
+            preferred_export_settings.export_settings.model_copy(
+                update={"generation_settings": generation_settings},
+                deep=True,
+            ),
+        )
+
     started_at = time.perf_counter()
     update_podcast_status_for_user(podcast_id, current_user.id, "processing")
 
     try:
-        score_segments = payload.score_segments or get_scored_segments_for_podcast(podcast_id, limit=5)
+
+        score_segments = payload.score_segments or get_scored_segments_for_podcast(
+            podcast_id,
+            limit=generation_settings.number_of_clips,
+        )
         transcription = payload.transcription
         refreshed_scores = False
 
@@ -246,6 +276,7 @@ async def generate_podcast_clips(
             score_segments,
             transcription,
             payload.export_settings,
+            generation_settings,
         )
     except (AnalysisError, ClippingError) as exc:
         update_podcast_status_for_user(podcast_id, current_user.id, "ready_for_processing")
@@ -257,6 +288,7 @@ async def generate_podcast_clips(
         clips,
         processing_time_seconds=round(time.perf_counter() - started_at, 3),
         export_settings=clips[0].export_settings if clips else None,
+        generation_settings=generation_settings,
     )
 
 

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -11,7 +11,7 @@ from app.config import BACKEND_DIR, ROOT_DIR
 from app.database import UnconfiguredSupabaseClient, service_supabase
 from app.models.analysis import ScoreSegment
 from app.models.clipping import ClipGenerationResult, ClipResult
-from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle
+from app.models.export_settings import ExportSettings, ExportSettingsInput, GenerationSettings, SubtitleStyle
 from app.models.media import SubtitleTimingContract
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.transcription import TranscriptWord, TranscriptionResult
@@ -23,7 +23,7 @@ import app.services.overlay_mapping_service as overlay_mapping_service_module
 GENERATED_CLIPS_ROOT = ROOT_DIR / ".generated" / "clips"
 CLIP_STORAGE_BUCKET = "clips"
 SIGNED_URL_TTL_SECONDS = 3600
-MAX_GENERATED_CLIPS = 5
+MAX_GENERATED_CLIPS = 10
 CLIP_LEAD_IN_SECONDS = 2.0
 CLIP_LEAD_OUT_SECONDS = 1.0
 OVERLAY_ASSETS_ROOT = BACKEND_DIR / "assets" / "overlays"
@@ -96,7 +96,7 @@ SUBTITLE_PRESET_RENDER_TUNING: dict[str, _SubtitleRenderTuning] = {
 def build_ffmpeg_clip_command(
     source_path: Path,
     output_path: Path,
-    subtitle_path: Path,
+    subtitle_path: Path | None,
     *,
     start_seconds: float,
     duration_seconds: float,
@@ -227,10 +227,12 @@ def generate_clips(
     score_segments: list[ScoreSegment],
     transcription: TranscriptionResult | None,
     export_settings: ExportSettingsInput | ExportSettings | None = None,
+    generation_settings: GenerationSettings | None = None,
 ) -> list[ClipResult]:
     podcast_row = _get_podcast_row(podcast_id)
     source_path = _resolve_source_media_path(podcast_row)
-    selected_segments = _select_segments(score_segments)
+    resolved_generation_settings = generation_settings or GenerationSettings()
+    selected_segments = _select_segments(score_segments, generation_settings=resolved_generation_settings)
     if not selected_segments:
         raise ClippingError("No scored segments are available for clip generation.", status_code=404)
 
@@ -244,7 +246,11 @@ def generate_clips(
 
     for clip_number, segment in enumerate(selected_segments, start=1):
         clip_id = str(uuid.uuid4())
-        clip_start, clip_end = _resolve_clip_window(segment, transcription)
+        clip_start, clip_end = _resolve_clip_window(
+            segment,
+            transcription,
+            target_duration_seconds=resolved_generation_settings.clip_duration_seconds,
+        )
         clip_duration = round(clip_end - clip_start, 3)
         if clip_duration <= 0:
             continue
@@ -259,19 +265,22 @@ def generate_clips(
                 resolved_export_settings,
                 clip_duration_seconds=clip_duration,
             )
-            if transcription is not None:
+            if resolved_generation_settings.subtitles_enabled and transcription is not None:
                 srt_content, subtitle_text = build_srt_content(
                     transcription,
                     clip_start_seconds=clip_start,
                     clip_end_seconds=clip_end,
                     export_settings=clip_export_settings,
                 )
-            else:
+            elif resolved_generation_settings.subtitles_enabled:
                 srt_content, subtitle_text = build_segment_fallback_srt_content(
                     segment,
                     clip_duration_seconds=clip_duration,
                     export_settings=clip_export_settings,
                 )
+            else:
+                srt_content = None
+                subtitle_text = ""
             draft_clip = ClipResult(
                 id=clip_id,
                 clip_number=clip_number,
@@ -283,17 +292,19 @@ def generate_clips(
                 subtitle_text=subtitle_text,
                 status="ready",
                 export_settings=clip_export_settings,
+                generation_settings=resolved_generation_settings,
             )
             overlay_decision = overlay_mapping_service_module.detect_overlay_decision(
                 podcast_id,
                 draft_clip,
                 segment,
             )
-            subtitle_path.write_text(srt_content, encoding="utf-8")
+            if srt_content is not None:
+                subtitle_path.write_text(srt_content, encoding="utf-8")
             final_overlay, clip_export_settings = _render_clip_with_optional_overlay(
                 source_path,
                 clip_path,
-                subtitle_path,
+                subtitle_path if srt_content is not None else None,
                 start_seconds=clip_start,
                 duration_seconds=clip_duration,
                 export_settings=clip_export_settings,
@@ -310,6 +321,7 @@ def generate_clips(
                         "video_url": video_url,
                         "overlay": final_overlay,
                         "export_settings": clip_export_settings,
+                        "generation_settings": resolved_generation_settings,
                     }
                 )
             )
@@ -324,7 +336,7 @@ def generate_clips(
                     "virality_score": segment.virality_score,
                     "storage_path": str(clip_path),
                     "storage_url": storage_url,
-                    "subtitle_url": subtitle_url or str(subtitle_path),
+                    "subtitle_url": subtitle_url or (str(subtitle_path) if srt_content is not None else None),
                     "subtitle_text": subtitle_text,
                     "status": "ready",
                     "preset_name": clip_export_settings.preset_name,
@@ -366,8 +378,12 @@ def build_clip_generation_result(
     *,
     processing_time_seconds: float,
     export_settings: ExportSettings | None = None,
+    generation_settings: GenerationSettings | None = None,
 ) -> ClipGenerationResult:
     resolved_export_settings = export_settings or (clips[0].export_settings if clips else ExportSettings())
+    resolved_generation_settings = generation_settings or (
+        clips[0].generation_settings if clips else resolved_export_settings.generation_settings
+    )
     return ClipGenerationResult(
         podcast_id=podcast_id,
         total_clips_generated=len(clips),
@@ -375,6 +391,7 @@ def build_clip_generation_result(
         processing_time_seconds=round(processing_time_seconds, 3),
         download_folder_url=f"/podcasts/{podcast_id}/clips",
         export_settings=resolved_export_settings,
+        generation_settings=resolved_generation_settings,
     )
 
 
@@ -456,38 +473,120 @@ def get_clip_podcast_id(clip_id: str) -> str | None:
     return str(rows[0]["podcast_id"])
 
 
-def _select_segments(score_segments: list[ScoreSegment]) -> list[ScoreSegment]:
-    return sorted(
+def _select_segments(
+    score_segments: list[ScoreSegment],
+    *,
+    generation_settings: GenerationSettings | None = None,
+) -> list[ScoreSegment]:
+    settings = generation_settings or GenerationSettings()
+    sorted_segments = sorted(
         score_segments,
-        key=lambda item: (-item.virality_score, item.segment_start_seconds),
-    )[:MAX_GENERATED_CLIPS]
+        key=lambda item: (
+            -_score_segment_for_generation(item, settings.topic_focus),
+            item.segment_start_seconds,
+        ),
+    )
+    return sorted_segments[:min(settings.number_of_clips, MAX_GENERATED_CLIPS)]
+
+
+def _score_segment_for_generation(segment: ScoreSegment, topic_focus: str | None) -> float:
+    score = float(segment.virality_score)
+    tokens = _topic_focus_tokens(topic_focus)
+    if not tokens:
+        return score
+    haystack = " ".join([segment.transcript_snippet, " ".join(segment.keywords)]).lower()
+    matches = sum(1 for token in tokens if token in haystack)
+    return score + (matches * 7.5)
+
+
+def _topic_focus_tokens(topic_focus: str | None) -> list[str]:
+    if not topic_focus:
+        return []
+    return [
+        token
+        for token in (_normalize_token(item) for item in topic_focus.replace(",", " ").split())
+        if len(token) >= 2
+    ]
 
 
 def _resolve_clip_window(
     segment: ScoreSegment,
     transcription: TranscriptionResult | None,
+    *,
+    target_duration_seconds: int | None = None,
 ) -> tuple[float, float]:
     if transcription is None:
-        return _expand_clip_window(
+        start, end = _expand_clip_window(
             segment.segment_start_seconds,
             segment.segment_end_seconds,
-            max_duration=max(segment.segment_end_seconds, segment.segment_start_seconds + 1.0),
+            max_duration=max(
+                segment.segment_end_seconds,
+                segment.segment_start_seconds + float(target_duration_seconds or 1.0),
+            ),
+        )
+        return _apply_requested_duration(
+            start,
+            end,
+            max_duration=max(end, segment.segment_start_seconds + float(target_duration_seconds or 1.0)),
+            target_duration_seconds=target_duration_seconds,
         )
 
     matched_window = _match_segment_snippet_window(segment, transcription.words)
     if matched_window is not None:
         start, end = matched_window
-        return _expand_clip_window(
+        expanded_start, expanded_end = _expand_clip_window(
             start,
             end,
             max_duration=transcription.duration_seconds,
         )
+        return _apply_requested_duration(
+            expanded_start,
+            expanded_end,
+            max_duration=transcription.duration_seconds,
+            target_duration_seconds=target_duration_seconds,
+        )
 
-    return _expand_clip_window(
+    expanded_start, expanded_end = _expand_clip_window(
         segment.segment_start_seconds,
         segment.segment_end_seconds,
         max_duration=transcription.duration_seconds,
     )
+    if not _collect_clip_words(
+        transcription.words,
+        clip_start_seconds=expanded_start,
+        clip_end_seconds=expanded_end,
+    ):
+        return expanded_start, expanded_end
+    return _apply_requested_duration(
+        expanded_start,
+        expanded_end,
+        max_duration=transcription.duration_seconds,
+        target_duration_seconds=target_duration_seconds,
+    )
+
+
+def _apply_requested_duration(
+    start_seconds: float,
+    end_seconds: float,
+    *,
+    max_duration: float,
+    target_duration_seconds: int | None,
+) -> tuple[float, float]:
+    if target_duration_seconds is None:
+        return start_seconds, end_seconds
+    target_duration = float(target_duration_seconds)
+    current_duration = round(end_seconds - start_seconds, 3)
+    if current_duration >= target_duration:
+        center = (start_seconds + end_seconds) / 2
+        adjusted_start = max(0.0, center - (target_duration / 2))
+        adjusted_end = min(max_duration, adjusted_start + target_duration)
+    else:
+        extra = target_duration - current_duration
+        adjusted_start = max(0.0, start_seconds - (extra / 2))
+        adjusted_end = min(max_duration, adjusted_start + target_duration)
+    if adjusted_end - adjusted_start < min(target_duration, max_duration):
+        adjusted_start = max(0.0, adjusted_end - target_duration)
+    return round(adjusted_start, 3), round(adjusted_end, 3)
 
 
 def _match_segment_snippet_window(
@@ -781,7 +880,7 @@ def _build_audio_filter(export_settings: ExportSettings | None = None) -> str | 
 
 
 def _build_video_filters(
-    subtitle_path: Path,
+    subtitle_path: Path | None,
     *,
     export_settings: ExportSettings | None = None,
     crop_window: CropWindow | None = None,
@@ -810,18 +909,19 @@ def _build_video_filters(
             )
         )
     filters.append("setpts=PTS-STARTPTS")
-    filters.append(
-        _build_subtitle_filter(
-            subtitle_path,
-            export_settings.subtitle_style if export_settings else None,
-            export_mode=render_contract.export_mode,
+    if subtitle_path is not None:
+        filters.append(
+            _build_subtitle_filter(
+                subtitle_path,
+                export_settings.subtitle_style if export_settings else None,
+                export_mode=render_contract.export_mode,
+            )
         )
-    )
     return ",".join(filters)
 
 
 def _build_video_filter_graph(
-    subtitle_path: Path,
+    subtitle_path: Path | None,
     overlay: OverlayDecision,
     *,
     export_settings: ExportSettings | None = None,
@@ -878,7 +978,7 @@ def _resolve_overlay_asset_path(asset_path: str | None) -> Path | None:
 def _render_clip_with_optional_overlay(
     source_path: Path,
     clip_path: Path,
-    subtitle_path: Path,
+    subtitle_path: Path | None,
     *,
     start_seconds: float,
     duration_seconds: float,
@@ -953,7 +1053,7 @@ def _render_clip_with_optional_overlay(
 def _run_ffmpeg_clip_generation(
     source_path: Path,
     clip_path: Path,
-    subtitle_path: Path,
+    subtitle_path: Path | None,
     *,
     start_seconds: float,
     duration_seconds: float,

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -13,7 +13,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.models.analysis import ScoreSegment  # noqa: E402
-from app.models.export_settings import ExportSettings, ExportSettingsInput, SubtitleStyle  # noqa: E402
+from app.models.export_settings import ExportSettings, ExportSettingsInput, GenerationSettings, SubtitleStyle  # noqa: E402
 from app.models.transcription import TranscriptWord, TranscriptionResult  # noqa: E402
 from app.models.overlay import OverlayDecision  # noqa: E402
 import app.services.clipping_service as clipping_service_module  # noqa: E402
@@ -27,6 +27,7 @@ from app.services.clipping_service import (  # noqa: E402
     _build_subtitle_force_style,
     _build_video_filters,
     _resolve_clip_window,
+    _select_segments,
 )
 
 
@@ -239,6 +240,54 @@ class ClippingServiceTests(unittest.TestCase):
             subtitle_text,
             "This is a strong hook for a viral clip and the subtitles should stay aligned.",
         )
+
+    def test_select_segments_honors_requested_clip_count_and_topic_focus(self) -> None:
+        segments = [
+            ScoreSegment(
+                segment_start_seconds=20.0,
+                segment_end_seconds=35.0,
+                duration_seconds=15.0,
+                virality_score=90.0,
+                transcript_snippet="General conversation about habits",
+                sentiment="neutral",
+                keywords=["habits"],
+            ),
+            ScoreSegment(
+                segment_start_seconds=40.0,
+                segment_end_seconds=55.0,
+                duration_seconds=15.0,
+                virality_score=84.0,
+                transcript_snippet="AI product launch with startup growth",
+                sentiment="positive",
+                keywords=["ai", "startup"],
+            ),
+            ScoreSegment(
+                segment_start_seconds=60.0,
+                segment_end_seconds=75.0,
+                duration_seconds=15.0,
+                virality_score=82.0,
+                transcript_snippet="Finance planning segment",
+                sentiment="neutral",
+                keywords=["finance"],
+            ),
+        ]
+
+        selected = _select_segments(
+            segments,
+            generation_settings=GenerationSettings(number_of_clips=1, topic_focus="AI startup"),
+        )
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0].transcript_snippet, "AI product launch with startup growth")
+
+    def test_resolve_clip_window_applies_requested_duration_when_possible(self) -> None:
+        clip_start, clip_end = _resolve_clip_window(
+            self.score_segments[0],
+            self.transcription,
+            target_duration_seconds=8,
+        )
+
+        self.assertEqual(round(clip_end - clip_start, 3), 8.0)
 
     def test_generate_clips_persists_ready_rows(self) -> None:
         case_dir = self._workspace_case_dir("clipping-persist")
@@ -680,6 +729,43 @@ class ClippingServiceTests(unittest.TestCase):
         self.assertEqual(clips[0].video_url, f"/podcasts/clips/{clips[0].id}/download")
         self.assertEqual(captured_command["start"], 0.0)
         self.assertGreater(captured_command["duration"], 5.0)
+
+    def test_generate_clips_can_disable_subtitles_for_output(self) -> None:
+        case_dir = self._workspace_case_dir("clipping-subtitles-disabled")
+        delete_execute = MagicMock()
+        insert_execute = MagicMock()
+        clips_table = SimpleNamespace(
+            delete=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=delete_execute)))),
+            insert=MagicMock(return_value=SimpleNamespace(execute=insert_execute)),
+        )
+        service_supabase_mock = MagicMock()
+        service_supabase_mock.table.side_effect = lambda name: clips_table if name == "clips" else MagicMock()
+        captured_subtitle_path = {"value": "not-set"}
+
+        def fake_ffmpeg(*args, **kwargs):
+            captured_subtitle_path["value"] = args[2]
+            clip_path = args[1]
+            clip_path.write_bytes(b"clip")
+
+        with patch.object(clipping_service_module, "service_supabase", service_supabase_mock):
+            with patch.object(clipping_service_module, "GENERATED_CLIPS_ROOT", case_dir / "generated"):
+                with patch.object(clipping_service_module, "_get_podcast_row", return_value={"id": "podcast-123"}):
+                    with patch.object(clipping_service_module, "_resolve_source_media_path", return_value=Path("podcast.mp4")):
+                        with patch.object(clipping_service_module, "_run_ffmpeg_clip_generation", side_effect=fake_ffmpeg):
+                            clips = generate_clips(
+                                "podcast-123",
+                                self.score_segments,
+                                self.transcription,
+                                generation_settings=GenerationSettings(subtitles_enabled=False),
+                            )
+
+        self.assertEqual(len(clips), 1)
+        self.assertEqual(clips[0].subtitle_text, "")
+        self.assertFalse(clips[0].generation_settings.subtitles_enabled)
+        self.assertIsNone(captured_subtitle_path["value"])
+        insert_payload = clips_table.insert.call_args.args[0]
+        self.assertEqual(insert_payload[0]["subtitle_text"], "")
+        self.assertIsNone(insert_payload[0]["subtitle_url"])
 
     def test_generate_clips_raises_when_segment_has_no_overlapping_words(self) -> None:
         invalid_segment = ScoreSegment(

--- a/backend/tests/test_export_settings_model.py
+++ b/backend/tests/test_export_settings_model.py
@@ -10,7 +10,15 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from app.models.export_settings import AudioEnhancementSettings, ExportSettings, ExportSettingsInput, SubtitleStyle  # noqa: E402
+from app.models.clipping import GenerateClipsRequest  # noqa: E402
+from app.models.export_settings import (  # noqa: E402
+    AudioEnhancementSettings,
+    ExportSettings,
+    ExportSettingsInput,
+    GenerationSettings,
+    GenerationSettingsInput,
+    SubtitleStyle,
+)
 
 
 class ExportSettingsModelTests(unittest.TestCase):
@@ -112,6 +120,81 @@ class ExportSettingsModelTests(unittest.TestCase):
     def test_audio_enhancement_rejects_unsafe_loudness_target(self) -> None:
         with self.assertRaises(ValidationError):
             AudioEnhancementSettings(target_lufs=-40.0)
+
+    def test_generation_settings_accepts_safe_user_preferences(self) -> None:
+        settings = GenerationSettings(
+            clip_duration_seconds=45,
+            number_of_clips=7,
+            topic_focus="AI growth, startup clips",
+            subtitles_enabled=False,
+        )
+
+        self.assertEqual(settings.clip_duration_seconds, 45)
+        self.assertEqual(settings.number_of_clips, 7)
+        self.assertEqual(settings.topic_focus, "AI growth, startup clips")
+        self.assertFalse(settings.subtitles_enabled)
+
+    def test_generation_settings_rejects_unsafe_values(self) -> None:
+        with self.assertRaises(ValidationError) as exc_info:
+            GenerationSettings(clip_duration_seconds=3, number_of_clips=30)
+
+        self.assertIn("clip_duration_seconds", str(exc_info.exception))
+        self.assertIn("number_of_clips", str(exc_info.exception))
+
+    def test_generation_settings_rejects_unsafe_topic_focus(self) -> None:
+        with self.assertRaises(ValidationError) as exc_info:
+            GenerationSettings(topic_focus="AI <script>")
+
+        self.assertIn("topic_focus can only contain", str(exc_info.exception))
+
+    def test_export_settings_can_persist_generation_preferences(self) -> None:
+        settings = ExportSettingsInput(
+            generation_settings={
+                "clip_duration_seconds": 60,
+                "number_of_clips": 4,
+                "subtitles_enabled": False,
+            }
+        ).resolve()
+
+        self.assertEqual(settings.generation_settings.clip_duration_seconds, 60)
+        self.assertEqual(settings.generation_settings.number_of_clips, 4)
+        self.assertFalse(settings.generation_settings.subtitles_enabled)
+
+    def test_generation_settings_input_resolves_over_preferred_defaults(self) -> None:
+        preferred = GenerationSettings(
+            clip_duration_seconds=40,
+            number_of_clips=6,
+            topic_focus="marketing",
+            subtitles_enabled=False,
+        )
+
+        resolved = GenerationSettingsInput(number_of_clips=3).resolve(preferred)
+
+        self.assertEqual(resolved.clip_duration_seconds, 40)
+        self.assertEqual(resolved.number_of_clips, 3)
+        self.assertEqual(resolved.topic_focus, "marketing")
+        self.assertFalse(resolved.subtitles_enabled)
+
+    def test_generate_clips_request_supports_direct_generation_fields(self) -> None:
+        request = GenerateClipsRequest(
+            clip_duration_seconds=35,
+            number_of_clips=2,
+            topic_focus="product launch",
+            subtitles_enabled=True,
+        )
+
+        resolved = request.resolve_generation_settings()
+
+        self.assertEqual(resolved.clip_duration_seconds, 35)
+        self.assertEqual(resolved.number_of_clips, 2)
+        self.assertEqual(resolved.topic_focus, "product launch")
+        self.assertTrue(resolved.subtitles_enabled)
+
+    def test_generate_clips_request_requires_settings_when_saving_preferences(self) -> None:
+        with self.assertRaises(ValidationError) as exc_info:
+            GenerateClipsRequest(save_generation_settings=True)
+
+        self.assertIn("save_generation_settings requires", str(exc_info.exception))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_podcasts_analysis_router.py
+++ b/backend/tests/test_podcasts_analysis_router.py
@@ -15,7 +15,7 @@ if str(BACKEND_ROOT) not in sys.path:
 from app.dependencies.auth import AuthenticatedUser  # noqa: E402
 from app.models.analysis import AnalysisResult, AnalyzePodcastRequest, ScoreSegment  # noqa: E402
 from app.models.clipping import ClipGenerationResult, ClipResult, GenerateClipsRequest  # noqa: E402
-from app.models.export_settings import ExportSettings  # noqa: E402
+from app.models.export_settings import ExportSettings, GenerationSettings  # noqa: E402
 from app.models.transcription import TranscriptionResult, TranscriptWord  # noqa: E402
 from app.routers.podcasts import (  # noqa: E402
     analyze_podcast,
@@ -47,6 +47,7 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         )
 
     @patch("app.routers.podcasts.generate_clips")
+    @patch("app.routers.podcasts.get_user_export_settings")
     @patch("app.routers.podcasts.persist_analysis_result")
     @patch("app.routers.podcasts.build_analysis_result")
     @patch("app.routers.podcasts.analyze_and_score")
@@ -59,8 +60,10 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         analyze_and_score_mock,
         build_analysis_result_mock,
         persist_analysis_result_mock,
+        get_user_export_settings_mock,
         generate_clips_mock,
     ) -> None:
+        get_user_export_settings_mock.return_value = None
         analyze_and_score_mock.return_value = [
             ScoreSegment(
                 segment_start_seconds=0.0,
@@ -118,10 +121,12 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         update_status_mock.assert_any_call("podcast-123", "user-123", "done")
         generate_clips_mock.assert_called_once()
         self.assertEqual(generate_clips_mock.call_args.args[3].resolve().export_mode, "portrait")
+        self.assertEqual(generate_clips_mock.call_args.args[4].number_of_clips, 5)
         analyze_and_score_mock.assert_not_called()
         persist_analysis_result_mock.assert_not_called()
 
     @patch("app.routers.podcasts.generate_clips")
+    @patch("app.routers.podcasts.get_user_export_settings")
     @patch("app.routers.podcasts.persist_analysis_result")
     @patch("app.routers.podcasts.build_analysis_result")
     @patch("app.routers.podcasts.transcribe_podcast_media_for_user")
@@ -136,8 +141,10 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         transcribe_podcast_mock,
         build_analysis_result_mock,
         persist_analysis_result_mock,
+        get_user_export_settings_mock,
         generate_clips_mock,
     ) -> None:
+        get_user_export_settings_mock.return_value = None
         get_scored_segments_mock.return_value = [
             ScoreSegment(
                 segment_start_seconds=5.0,
@@ -179,6 +186,7 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         persist_analysis_result_mock.assert_not_called()
 
     @patch("app.routers.podcasts.generate_clips")
+    @patch("app.routers.podcasts.get_user_export_settings")
     @patch("app.routers.podcasts.persist_analysis_result")
     @patch("app.routers.podcasts.build_analysis_result")
     @patch("app.routers.podcasts.analyze_and_score")
@@ -195,8 +203,10 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         analyze_and_score_mock,
         build_analysis_result_mock,
         persist_analysis_result_mock,
+        get_user_export_settings_mock,
         generate_clips_mock,
     ) -> None:
+        get_user_export_settings_mock.return_value = None
         get_scored_segments_mock.return_value = [
             ScoreSegment(
                 segment_start_seconds=0.0,
@@ -249,6 +259,92 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         analyze_and_score_mock.assert_called_once_with("podcast-123", self.payload.transcription)
         build_analysis_result_mock.assert_called_once()
         persist_analysis_result_mock.assert_called_once()
+
+    @patch("app.routers.podcasts.update_user_export_settings")
+    @patch("app.routers.podcasts.get_user_export_settings")
+    @patch("app.routers.podcasts.generate_clips")
+    @patch("app.routers.podcasts.get_scored_segments_for_podcast")
+    @patch("app.routers.podcasts.update_podcast_status_for_user")
+    @patch("app.routers.podcasts.podcast_belongs_to_user", return_value=True)
+    def test_generate_podcast_clips_reuses_and_saves_generation_settings(
+        self,
+        podcast_belongs_mock,
+        update_status_mock,
+        get_scored_segments_mock,
+        generate_clips_mock,
+        get_user_export_settings_mock,
+        update_user_export_settings_mock,
+    ) -> None:
+        preferred_export_settings = ExportSettings(
+            generation_settings=GenerationSettings(
+                clip_duration_seconds=45,
+                number_of_clips=4,
+                topic_focus="ai",
+                subtitles_enabled=False,
+            )
+        )
+        get_user_export_settings_mock.return_value = type(
+            "SettingsResponse",
+            (),
+            {
+                "user_id": "user-123",
+                "export_settings": preferred_export_settings,
+            },
+        )()
+        get_scored_segments_mock.return_value = [
+            ScoreSegment(
+                segment_start_seconds=5.0,
+                segment_end_seconds=35.0,
+                duration_seconds=30.0,
+                virality_score=88.0,
+                transcript_snippet="AI launch segment",
+                sentiment="positive",
+                keywords=["ai"],
+            )
+        ]
+        generate_clips_mock.return_value = [
+            ClipResult(
+                id="clip-1",
+                clip_number=1,
+                clip_start_seconds=5.0,
+                clip_end_seconds=35.0,
+                duration_seconds=30.0,
+                virality_score=88.0,
+                video_url="https://example.com/clip-1.mp4",
+                subtitle_text="",
+                status="ready",
+                generation_settings=GenerationSettings(
+                    clip_duration_seconds=30,
+                    number_of_clips=2,
+                    topic_focus="product launch",
+                    subtitles_enabled=False,
+                ),
+            )
+        ]
+
+        result = asyncio.run(
+            generate_podcast_clips(
+                "podcast-123",
+                GenerateClipsRequest(
+                    use_preferred_generation_settings=True,
+                    save_generation_settings=True,
+                    number_of_clips=2,
+                    clip_duration_seconds=30,
+                    topic_focus="product launch",
+                ),
+                self.user,
+            )
+        )
+
+        self.assertEqual(result.generation_settings.number_of_clips, 2)
+        self.assertEqual(result.generation_settings.clip_duration_seconds, 30)
+        self.assertEqual(result.generation_settings.topic_focus, "product launch")
+        self.assertFalse(result.generation_settings.subtitles_enabled)
+        get_scored_segments_mock.assert_called_once_with("podcast-123", limit=2)
+        generate_clips_mock.assert_called_once()
+        self.assertEqual(generate_clips_mock.call_args.args[4].topic_focus, "product launch")
+        update_user_export_settings_mock.assert_called_once()
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
 
     @patch("app.routers.podcasts.persist_analysis_result")
     @patch("app.routers.podcasts.build_analysis_result")


### PR DESCRIPTION
## Summary
This PR completes **Sprint 11 - Job 1: Backend Generation Settings and Clip Configuration**.

It adds backend support for user-controlled clip generation settings. Users can now send preferences for clip duration, number of clips, topic focus, and whether subtitles should be included.

## What Changed
- Added generation settings models for backend validation
- Added request fields for:
  - clip duration
  - number of clips
  - topic focus
  - subtitles on/off
- Added support for saving and reusing preferred generation settings
- Updated clip generation so the selected settings affect:
  - how many clips are generated
  - target clip duration
  - segment ranking based on topic focus
  - subtitle rendering behavior
- Added a defaults endpoint for frontend integration:
  - `GET /clips/generation-settings/defaults`
- Updated response contracts so generated clips return the generation settings used
- Added tests for valid, invalid, and edge-case settings payloads

## Tests
- Sprint 11 targeted backend tests passed
- Full backend regression tests passed
