### PR TITLE
Sprint 11 Job 3: add visual output modes and format-aware subtitles

### DIFF
--- a/backend/app/models/clipping.py
+++ b/backend/app/models/clipping.py
@@ -12,6 +12,7 @@ from app.models.export_settings import (
     GenerationSettings,
     GenerationSettingsInput,
 )
+from app.models.media import VisualOutputMode
 from app.models.overlay import OverlayDecision
 from app.models.transcription import TranscriptionResult
 
@@ -34,6 +35,9 @@ class ClipResult(BaseModel):
     overlay: OverlayDecision | None = None
     export_settings: ExportSettings = Field(default_factory=ExportSettings)
     generation_settings: GenerationSettings = Field(default_factory=GenerationSettings)
+    visual_output_mode: VisualOutputMode = "original_people"
+    effective_visual_output_mode: VisualOutputMode = "original_people"
+    render_fallback_reason: str | None = None
 
     @field_validator("id", "video_url")
     @classmethod
@@ -80,6 +84,7 @@ class GenerateClipsRequest(BaseModel):
     number_of_clips: int | None = Field(default=None, ge=1, le=10)
     topic_focus: str | None = Field(default=None, max_length=120)
     subtitles_enabled: bool | None = None
+    visual_output_mode: VisualOutputMode = "original_people"
     save_generation_settings: bool = False
     use_preferred_generation_settings: bool = False
 

--- a/backend/app/models/media.py
+++ b/backend/app/models/media.py
@@ -1,6 +1,13 @@
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.export_settings import ExportMode, ExportPresetName, SubtitleTimingProfile
+
+VisualOutputMode = Literal["original_people", "book_like", "stylized_animated"]
+OverlayRenderPolicy = Literal["full", "limited", "disabled"]
+SubtitleRenderPolicy = Literal["spoken_captions", "narrative_cards", "stylized_captions"]
+RenderingProfile = Literal["live_action", "editorial_frame", "motion_graphic"]
 
 
 class MediaInspectionResult(BaseModel):
@@ -28,6 +35,12 @@ class MediaRenderContract(BaseModel):
 
     preset_name: ExportPresetName
     export_mode: ExportMode
+    requested_visual_output_mode: VisualOutputMode = "original_people"
+    effective_visual_output_mode: VisualOutputMode = "original_people"
+    rendering_profile: RenderingProfile = "live_action"
+    overlay_policy: OverlayRenderPolicy = "full"
+    subtitle_policy: SubtitleRenderPolicy = "spoken_captions"
+    render_fallback_reason: str | None = None
     width: int = Field(ge=360)
     height: int = Field(ge=360)
     aspect_ratio: str

--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -277,6 +277,7 @@ async def generate_podcast_clips(
             transcription,
             payload.export_settings,
             generation_settings,
+            payload.visual_output_mode,
         )
     except (AnalysisError, ClippingError) as exc:
         update_podcast_status_for_user(podcast_id, current_user.id, "ready_for_processing")

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import shutil
 import subprocess
 import uuid
@@ -12,7 +13,7 @@ from app.database import UnconfiguredSupabaseClient, service_supabase
 from app.models.analysis import ScoreSegment
 from app.models.clipping import ClipGenerationResult, ClipResult
 from app.models.export_settings import ExportSettings, ExportSettingsInput, GenerationSettings, SubtitleStyle
-from app.models.media import SubtitleTimingContract
+from app.models.media import SubtitleTimingContract, VisualOutputMode
 from app.models.overlay import OverlayDecision, OverlayMappingResult
 from app.models.transcription import TranscriptWord, TranscriptionResult
 from app.services.media_service import build_render_contract, resolve_export_settings_for_render
@@ -101,6 +102,7 @@ def build_ffmpeg_clip_command(
     start_seconds: float,
     duration_seconds: float,
     export_settings: ExportSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
     crop_window: CropWindow | None = None,
     overlay: OverlayDecision | None = None,
     overlay_asset_path: Path | None = None,
@@ -135,6 +137,7 @@ def build_ffmpeg_clip_command(
                     subtitle_path,
                     overlay,
                     export_settings=export_settings,
+                    visual_output_mode=visual_output_mode,
                     crop_window=crop_window,
                     clip_duration_seconds=duration_seconds,
                 ),
@@ -151,6 +154,7 @@ def build_ffmpeg_clip_command(
                 _build_video_filters(
                     subtitle_path,
                     export_settings=export_settings,
+                    visual_output_mode=visual_output_mode,
                     crop_window=crop_window,
                     clip_duration_seconds=duration_seconds,
                 ),
@@ -187,6 +191,7 @@ def build_srt_content(
     clip_start_seconds: float,
     clip_end_seconds: float,
     export_settings: ExportSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
 ) -> tuple[str, str]:
     clip_words = _collect_clip_words(
         transcription.words,
@@ -201,6 +206,8 @@ def build_srt_content(
         clip_start_seconds=clip_start_seconds,
         subtitle_timing=build_render_contract(
             export_settings,
+            visual_output_mode=visual_output_mode,
+            subtitles_available=True,
             clip_duration_seconds=round(clip_end_seconds - clip_start_seconds, 3),
         ).subtitle_timing,
     )
@@ -228,6 +235,7 @@ def generate_clips(
     transcription: TranscriptionResult | None,
     export_settings: ExportSettingsInput | ExportSettings | None = None,
     generation_settings: GenerationSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
 ) -> list[ClipResult]:
     podcast_row = _get_podcast_row(podcast_id)
     source_path = _resolve_source_media_path(podcast_row)
@@ -263,6 +271,14 @@ def generate_clips(
         try:
             clip_export_settings = resolve_export_settings_for_render(
                 resolved_export_settings,
+                visual_output_mode=visual_output_mode,
+                subtitles_available=resolved_generation_settings.subtitles_enabled,
+                clip_duration_seconds=clip_duration,
+            )
+            render_contract = build_render_contract(
+                clip_export_settings,
+                visual_output_mode=visual_output_mode,
+                subtitles_available=resolved_generation_settings.subtitles_enabled,
                 clip_duration_seconds=clip_duration,
             )
             if resolved_generation_settings.subtitles_enabled and transcription is not None:
@@ -271,12 +287,14 @@ def generate_clips(
                     clip_start_seconds=clip_start,
                     clip_end_seconds=clip_end,
                     export_settings=clip_export_settings,
+                    visual_output_mode=visual_output_mode,
                 )
             elif resolved_generation_settings.subtitles_enabled:
                 srt_content, subtitle_text = build_segment_fallback_srt_content(
                     segment,
                     clip_duration_seconds=clip_duration,
                     export_settings=clip_export_settings,
+                    visual_output_mode=visual_output_mode,
                 )
             else:
                 srt_content = None
@@ -293,6 +311,9 @@ def generate_clips(
                 status="ready",
                 export_settings=clip_export_settings,
                 generation_settings=resolved_generation_settings,
+                visual_output_mode=visual_output_mode,
+                effective_visual_output_mode=render_contract.effective_visual_output_mode,
+                render_fallback_reason=render_contract.render_fallback_reason,
             )
             overlay_decision = overlay_mapping_service_module.detect_overlay_decision(
                 podcast_id,
@@ -308,6 +329,7 @@ def generate_clips(
                 start_seconds=clip_start,
                 duration_seconds=clip_duration,
                 export_settings=clip_export_settings,
+                visual_output_mode=visual_output_mode,
                 overlay=overlay_decision,
             )
             # Keep generation responsive by returning locally rendered clips immediately.
@@ -322,6 +344,9 @@ def generate_clips(
                         "overlay": final_overlay,
                         "export_settings": clip_export_settings,
                         "generation_settings": resolved_generation_settings,
+                        "visual_output_mode": visual_output_mode,
+                        "effective_visual_output_mode": render_contract.effective_visual_output_mode,
+                        "render_fallback_reason": render_contract.render_fallback_reason,
                     }
                 )
             )
@@ -724,11 +749,7 @@ def _finalize_subtitle_cue(
     start = max(0.0, round(words[0].start - clip_start_seconds, 3))
     end = max(start + 0.08, round(words[-1].end - clip_start_seconds, 3))
     tokens = [word.word for word in words]
-    midpoint = len(tokens) // 2
-    if max_lines > 1 and len(tokens) >= 8:
-        text = f"{_join_transcript_tokens(tokens[:midpoint])}\n{_join_transcript_tokens(tokens[midpoint:])}"
-    else:
-        text = _join_transcript_tokens(tokens)
+    text = _format_subtitle_lines(tokens, max_lines=max_lines)
     return _SubtitleCue(start=start, end=end, text=text)
 
 
@@ -737,6 +758,7 @@ def build_segment_fallback_srt_content(
     *,
     clip_duration_seconds: float,
     export_settings: ExportSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
 ) -> tuple[str, str]:
     subtitle_text = _join_transcript_tokens(segment.transcript_snippet.split())
     if not subtitle_text:
@@ -744,22 +766,25 @@ def build_segment_fallback_srt_content(
 
     subtitle_timing = build_render_contract(
         export_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=True,
         clip_duration_seconds=clip_duration_seconds,
     ).subtitle_timing
     tokens = subtitle_text.split()
-    lines: list[str] = []
+    chunks: list[list[str]] = []
     current_tokens: list[str] = []
     for token in tokens:
         current_tokens.append(token)
         if len(current_tokens) >= subtitle_timing.max_words_per_cue:
-            lines.append(" ".join(current_tokens))
+            chunks.append(current_tokens)
             current_tokens = []
     if current_tokens:
-        lines.append(" ".join(current_tokens))
+        chunks.append(current_tokens)
 
-    if not lines:
-        lines = [subtitle_text]
+    if not chunks:
+        chunks = [tokens]
 
+    lines = [_format_subtitle_lines(chunk, max_lines=subtitle_timing.max_lines) for chunk in chunks]
     cue_count = len(lines)
     duration_per_cue = min(
         subtitle_timing.max_duration_seconds,
@@ -784,6 +809,37 @@ def build_segment_fallback_srt_content(
         )
 
     return "\n".join(srt_lines).strip(), subtitle_text
+
+
+def _format_subtitle_lines(tokens: list[str], *, max_lines: int) -> str:
+    cleaned_tokens = [str(token).strip() for token in tokens if str(token).strip()]
+    if not cleaned_tokens:
+        return ""
+
+    if max_lines <= 1 or len(cleaned_tokens) <= 4:
+        return _join_transcript_tokens(cleaned_tokens)
+
+    if max_lines >= 3:
+        line_count = 3 if len(cleaned_tokens) >= 8 else 2
+    else:
+        line_count = 2 if len(cleaned_tokens) >= 7 else 1
+
+    line_count = min(line_count, max_lines)
+    if line_count <= 1:
+        return _join_transcript_tokens(cleaned_tokens)
+
+    base_size = len(cleaned_tokens) // line_count
+    remainder = len(cleaned_tokens) % line_count
+    lines: list[str] = []
+    start_index = 0
+
+    for line_index in range(line_count):
+        chunk_size = base_size + (1 if line_index < remainder else 0)
+        end_index = start_index + max(1, chunk_size)
+        lines.append(_join_transcript_tokens(cleaned_tokens[start_index:end_index]))
+        start_index = end_index
+
+    return "\n".join(line for line in lines if line)
 
 
 def _join_transcript_tokens(tokens: Any) -> str:
@@ -879,15 +935,26 @@ def _build_audio_filter(export_settings: ExportSettings | None = None) -> str | 
     )
 
 
+def _build_visual_mode_video_filter(render_contract: Any) -> str | None:
+    if render_contract.effective_visual_output_mode == "book_like":
+        return "eq=saturation=0.84:contrast=1.04:brightness=0.02"
+    if render_contract.effective_visual_output_mode == "stylized_animated":
+        return "eq=saturation=1.10:contrast=1.08:brightness=0.01"
+    return None
+
+
 def _build_video_filters(
     subtitle_path: Path | None,
     *,
     export_settings: ExportSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
     crop_window: CropWindow | None = None,
     clip_duration_seconds: float | None = None,
 ) -> str:
     render_contract = build_render_contract(
         export_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitle_path is not None,
         clip_duration_seconds=clip_duration_seconds,
     )
     filters: list[str] = []
@@ -908,6 +975,9 @@ def _build_video_filters(
                 f"pad={render_contract.width}:{render_contract.height}:(ow-iw)/2:(oh-ih)/2"
             )
         )
+    visual_mode_filter = _build_visual_mode_video_filter(render_contract)
+    if visual_mode_filter is not None:
+        filters.append(visual_mode_filter)
     filters.append("setpts=PTS-STARTPTS")
     if subtitle_path is not None:
         filters.append(
@@ -925,12 +995,14 @@ def _build_video_filter_graph(
     overlay: OverlayDecision,
     *,
     export_settings: ExportSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
     crop_window: CropWindow | None = None,
     clip_duration_seconds: float | None = None,
 ) -> str:
     subtitle_filter = _build_video_filters(
         subtitle_path,
         export_settings=export_settings,
+        visual_output_mode=visual_output_mode,
         crop_window=crop_window,
         clip_duration_seconds=clip_duration_seconds,
     )
@@ -983,6 +1055,7 @@ def _render_clip_with_optional_overlay(
     start_seconds: float,
     duration_seconds: float,
     export_settings: ExportSettings,
+    visual_output_mode: VisualOutputMode = "original_people",
     overlay: OverlayDecision,
 ) -> tuple[OverlayDecision, ExportSettings]:
     crop_window = _resolve_crop_window(
@@ -990,6 +1063,12 @@ def _render_clip_with_optional_overlay(
         start_seconds=start_seconds,
         duration_seconds=duration_seconds,
         export_settings=export_settings,
+    )
+    render_contract = build_render_contract(
+        export_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitle_path is not None,
+        clip_duration_seconds=duration_seconds,
     )
     if not overlay.applied:
         final_export_settings = _run_ffmpeg_clip_generation(
@@ -999,13 +1078,40 @@ def _render_clip_with_optional_overlay(
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
             export_settings=export_settings,
+            visual_output_mode=visual_output_mode,
             crop_window=crop_window,
         )
         if final_export_settings is None:
             final_export_settings = export_settings
         return overlay.model_copy(update={"rendered": False, "render_status": "no_match"}), final_export_settings
 
-    overlay_asset_path = _resolve_overlay_asset_path(overlay.asset_path)
+    if render_contract.overlay_policy == "disabled":
+        final_export_settings = _run_ffmpeg_clip_generation(
+            source_path,
+            clip_path,
+            subtitle_path,
+            start_seconds=start_seconds,
+            duration_seconds=duration_seconds,
+            export_settings=export_settings,
+            visual_output_mode=visual_output_mode,
+            crop_window=crop_window,
+        )
+        if final_export_settings is None:
+            final_export_settings = export_settings
+        return overlay.model_copy(update={"rendered": False, "render_status": "mode_disabled"}), final_export_settings
+
+    overlay_for_render = overlay
+    success_status = "rendered"
+    if render_contract.overlay_policy == "limited":
+        overlay_for_render = overlay.model_copy(
+            update={
+                "opacity": min(float(overlay.opacity or 0.9), 0.58),
+                "scale": min(float(overlay.scale or 0.18), 0.14),
+            }
+        )
+        success_status = "mode_limited"
+
+    overlay_asset_path = _resolve_overlay_asset_path(overlay_for_render.asset_path)
     if overlay_asset_path is None:
         final_export_settings = _run_ffmpeg_clip_generation(
             source_path,
@@ -1014,6 +1120,7 @@ def _render_clip_with_optional_overlay(
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
             export_settings=export_settings,
+            visual_output_mode=visual_output_mode,
             crop_window=crop_window,
         )
         if final_export_settings is None:
@@ -1028,13 +1135,14 @@ def _render_clip_with_optional_overlay(
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
             export_settings=export_settings,
+            visual_output_mode=visual_output_mode,
             crop_window=crop_window,
-            overlay=overlay,
+            overlay=overlay_for_render,
             overlay_asset_path=overlay_asset_path,
         )
         if final_export_settings is None:
             final_export_settings = export_settings
-        return overlay.model_copy(update={"rendered": True, "render_status": "rendered"}), final_export_settings
+        return overlay_for_render.model_copy(update={"rendered": True, "render_status": success_status}), final_export_settings
     except ClippingError:
         final_export_settings = _run_ffmpeg_clip_generation(
             source_path,
@@ -1043,6 +1151,7 @@ def _render_clip_with_optional_overlay(
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
             export_settings=export_settings,
+            visual_output_mode=visual_output_mode,
             crop_window=crop_window,
         )
         if final_export_settings is None:
@@ -1058,6 +1167,7 @@ def _run_ffmpeg_clip_generation(
     start_seconds: float,
     duration_seconds: float,
     export_settings: ExportSettings | None = None,
+    visual_output_mode: VisualOutputMode = "original_people",
     crop_window: CropWindow | None = None,
     overlay: OverlayDecision | None = None,
     overlay_asset_path: Path | None = None,
@@ -1073,6 +1183,7 @@ def _run_ffmpeg_clip_generation(
         start_seconds=start_seconds,
         duration_seconds=duration_seconds,
         export_settings=resolved_export_settings,
+        visual_output_mode=visual_output_mode,
         crop_window=crop_window,
         overlay=overlay,
         overlay_asset_path=overlay_asset_path,
@@ -1092,6 +1203,7 @@ def _run_ffmpeg_clip_generation(
             start_seconds=start_seconds,
             duration_seconds=duration_seconds,
             export_settings=fallback_export_settings,
+            visual_output_mode=visual_output_mode,
             crop_window=crop_window,
             overlay=overlay,
             overlay_asset_path=overlay_asset_path,

--- a/backend/app/services/media_service.py
+++ b/backend/app/services/media_service.py
@@ -10,6 +10,7 @@ from app.models.export_settings import (
     SubtitleTimingProfile,
 )
 from app.models.media import MediaInspectionResult, MediaRenderContract, SubtitleTimingContract
+from app.models.media import VisualOutputMode
 from app.utils.media import inspect_media
 
 
@@ -91,11 +92,18 @@ PRESET_SPECS: dict[ExportPresetName, _PresetSpec] = {
 def resolve_export_settings_for_render(
     export_settings: ExportSettingsInput | ExportSettings | None,
     *,
+    visual_output_mode: VisualOutputMode = "original_people",
+    subtitles_available: bool = True,
     clip_duration_seconds: float | None = None,
 ) -> ExportSettings:
     base_settings = _coerce_export_settings(export_settings).model_copy(deep=True)
     preset = PRESET_SPECS[base_settings.preset_name]
     subtitle_timing_profile = base_settings.subtitle_timing_profile or preset.subtitle_timing_profile
+    mode_behavior = _resolve_visual_mode_behavior(
+        base_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitles_available,
+    )
 
     if preset.export_mode == "landscape":
         crop_mode = "none"
@@ -115,6 +123,7 @@ def resolve_export_settings_for_render(
         export_mode=preset.export_mode,
         subtitle_timing_profile=subtitle_timing_profile,
         clip_duration_seconds=clip_duration_seconds,
+        visual_output_mode=mode_behavior["effective_visual_output_mode"],
     )
 
     return base_settings.model_copy(
@@ -133,39 +142,71 @@ def resolve_export_settings_for_render(
 def build_render_contract(
     export_settings: ExportSettingsInput | ExportSettings | None,
     *,
+    visual_output_mode: VisualOutputMode = "original_people",
+    subtitles_available: bool = True,
     clip_duration_seconds: float | None = None,
 ) -> MediaRenderContract:
     resolved_settings = resolve_export_settings_for_render(
         export_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitles_available,
         clip_duration_seconds=clip_duration_seconds,
     )
     preset = PRESET_SPECS[resolved_settings.preset_name]
+    mode_behavior = _resolve_visual_mode_behavior(
+        resolved_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitles_available,
+    )
     subtitle_timing = build_subtitle_timing_contract(
         resolved_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitles_available,
         clip_duration_seconds=clip_duration_seconds,
     )
+    overlay_margin_x = preset.overlay_safe_margin_x
+    overlay_margin_y = preset.overlay_safe_margin_y
+    if mode_behavior["effective_visual_output_mode"] == "book_like":
+        overlay_margin_x += 10
+        overlay_margin_y += 18
+    elif mode_behavior["effective_visual_output_mode"] == "stylized_animated":
+        overlay_margin_x += 14
+        overlay_margin_y += 26
     return MediaRenderContract(
         preset_name=resolved_settings.preset_name,
         export_mode=resolved_settings.export_mode,
+        requested_visual_output_mode=visual_output_mode,
+        effective_visual_output_mode=mode_behavior["effective_visual_output_mode"],
+        rendering_profile=mode_behavior["rendering_profile"],
+        overlay_policy=mode_behavior["overlay_policy"],
+        subtitle_policy=mode_behavior["subtitle_policy"],
+        render_fallback_reason=mode_behavior["render_fallback_reason"],
         width=preset.width,
         height=preset.height,
         aspect_ratio=preset.aspect_ratio,
         subtitle_timing_profile=resolved_settings.subtitle_timing_profile,
         subtitle_timing=subtitle_timing,
-        overlay_safe_margin_x=preset.overlay_safe_margin_x,
-        overlay_safe_margin_y=preset.overlay_safe_margin_y,
+        overlay_safe_margin_x=overlay_margin_x,
+        overlay_safe_margin_y=overlay_margin_y,
     )
 
 
 def build_subtitle_timing_contract(
     export_settings: ExportSettingsInput | ExportSettings | None,
     *,
+    visual_output_mode: VisualOutputMode = "original_people",
+    subtitles_available: bool = True,
     clip_duration_seconds: float | None = None,
 ) -> SubtitleTimingContract:
     resolved_settings = _coerce_export_settings(export_settings)
     duration = max(float(clip_duration_seconds or 30.0), 1.0)
     duration_bucket = "short" if duration <= 18 else "long" if duration >= 55 else "medium"
     profile = resolved_settings.subtitle_timing_profile
+    mode_behavior = _resolve_visual_mode_behavior(
+        resolved_settings,
+        visual_output_mode=visual_output_mode,
+        subtitles_available=subtitles_available,
+    )
 
     presets: dict[SubtitleTimingProfile, dict[str, tuple[int, float, float]]] = {
         "compact": {
@@ -191,11 +232,27 @@ def build_subtitle_timing_contract(
         max_duration_seconds = min(max_duration_seconds, 3.0)
         gap_seconds = max(0.2, gap_seconds - 0.04)
 
+    if mode_behavior["effective_visual_output_mode"] == "book_like":
+        max_words_per_cue = max(3, max_words_per_cue - 2)
+        max_duration_seconds = min(4.0, max_duration_seconds + 0.35)
+        gap_seconds = min(0.8, gap_seconds + 0.08)
+    elif mode_behavior["effective_visual_output_mode"] == "stylized_animated":
+        max_words_per_cue = max(3, max_words_per_cue - 2)
+        max_duration_seconds = min(max_duration_seconds, 2.4)
+        gap_seconds = max(0.18, gap_seconds - 0.06)
+
+    max_lines = 3 if resolved_settings.export_mode == "portrait" else 2
+    if mode_behavior["subtitle_policy"] == "narrative_cards":
+        max_lines = 3
+    elif mode_behavior["subtitle_policy"] == "stylized_captions":
+        max_lines = 2 if duration <= 18 else 3
+    max_lines = max(1, min(max_lines, 3))
+
     return SubtitleTimingContract(
         max_words_per_cue=max_words_per_cue,
         max_duration_seconds=round(max_duration_seconds, 2),
         gap_seconds=round(gap_seconds, 2),
-        max_lines=2,
+        max_lines=max_lines,
     )
 
 
@@ -215,6 +272,7 @@ def _tune_subtitle_style(
     export_mode: ExportMode,
     subtitle_timing_profile: SubtitleTimingProfile,
     clip_duration_seconds: float | None,
+    visual_output_mode: VisualOutputMode,
 ) -> SubtitleStyle:
     tuned = subtitle_style.model_copy(deep=True)
     duration = max(float(clip_duration_seconds or 30.0), 1.0)
@@ -242,4 +300,76 @@ def _tune_subtitle_style(
     if export_mode == "portrait" and tuned.position == "bottom" and duration >= 45:
         tuned.position = "center"
 
+    if visual_output_mode == "book_like":
+        if tuned.font_family == "Arial":
+            tuned.font_family = "Georgia"
+        tuned.italic = True
+        tuned.position = "top"
+        tuned.background_opacity = max(tuned.background_opacity, 0.42)
+        tuned.font_size = max(tuned.font_size, 20 if export_mode == "landscape" else 22)
+    elif visual_output_mode == "stylized_animated":
+        if tuned.font_family == "Arial":
+            tuned.font_family = "DM Sans"
+        tuned.bold = True
+        tuned.position = "center"
+        tuned.background_opacity = max(tuned.background_opacity, 0.58)
+        tuned.font_size = max(tuned.font_size, 24 if export_mode == "portrait" else 20)
+
     return tuned
+
+
+def _resolve_visual_mode_behavior(
+    export_settings: ExportSettings,
+    *,
+    visual_output_mode: VisualOutputMode,
+    subtitles_available: bool,
+) -> dict[str, str | None]:
+    if visual_output_mode == "book_like":
+        if not subtitles_available:
+            return {
+                "effective_visual_output_mode": "original_people",
+                "rendering_profile": "live_action",
+                "overlay_policy": "full",
+                "subtitle_policy": "spoken_captions",
+                "render_fallback_reason": "book_like_requires_subtitles",
+            }
+        return {
+            "effective_visual_output_mode": "book_like",
+            "rendering_profile": "editorial_frame",
+            "overlay_policy": "disabled",
+            "subtitle_policy": "narrative_cards",
+            "render_fallback_reason": None,
+        }
+
+    if visual_output_mode == "stylized_animated":
+        if export_settings.export_mode != "portrait":
+            return {
+                "effective_visual_output_mode": "original_people",
+                "rendering_profile": "live_action",
+                "overlay_policy": "full",
+                "subtitle_policy": "spoken_captions",
+                "render_fallback_reason": "stylized_animated_requires_portrait_export",
+            }
+        if not subtitles_available:
+            return {
+                "effective_visual_output_mode": "original_people",
+                "rendering_profile": "live_action",
+                "overlay_policy": "full",
+                "subtitle_policy": "spoken_captions",
+                "render_fallback_reason": "stylized_animated_requires_subtitles",
+            }
+        return {
+            "effective_visual_output_mode": "stylized_animated",
+            "rendering_profile": "motion_graphic",
+            "overlay_policy": "limited",
+            "subtitle_policy": "stylized_captions",
+            "render_fallback_reason": None,
+        }
+
+    return {
+        "effective_visual_output_mode": "original_people",
+        "rendering_profile": "live_action",
+        "overlay_policy": "full",
+        "subtitle_policy": "spoken_captions",
+        "render_fallback_reason": None,
+    }

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -217,6 +217,24 @@ class ClippingServiceTests(unittest.TestCase):
 
         self.assertNotIn("-af", command)
 
+    def test_build_ffmpeg_clip_command_applies_visual_mode_filter_chain(self) -> None:
+        command = build_ffmpeg_clip_command(
+            Path("input.mp4"),
+            Path("output.mp4"),
+            Path("captions.srt"),
+            start_seconds=0,
+            duration_seconds=12,
+            export_settings=ExportSettingsInput(
+                export_mode="portrait",
+                crop_mode="smart_crop",
+            ).resolve(),
+            visual_output_mode="book_like",
+        )
+
+        self.assertIn("-vf", command)
+        filters = command[command.index("-vf") + 1]
+        self.assertIn("eq=saturation=0.84:contrast=1.04:brightness=0.02", filters)
+
     def test_build_srt_content_offsets_timestamps_relative_to_clip_start(self) -> None:
         srt_content, subtitle_text = build_srt_content(
             self.transcription,
@@ -235,11 +253,33 @@ class ClippingServiceTests(unittest.TestCase):
         )
 
         self.assertIn("00:00:00,000 -->", srt_content)
-        self.assertIn("This is a strong hook", srt_content)
+        self.assertIn("This is a strong\nhook for a", srt_content)
         self.assertEqual(
             subtitle_text,
             "This is a strong hook for a viral clip and the subtitles should stay aligned.",
         )
+
+    def test_build_srt_content_uses_more_lines_for_portrait_video(self) -> None:
+        srt_content, _ = build_srt_content(
+            self.transcription,
+            clip_start_seconds=2.0,
+            clip_end_seconds=6.2,
+            export_settings=ExportSettingsInput(
+                export_mode="portrait",
+                crop_mode="smart_crop",
+            ).resolve(),
+        )
+
+        self.assertIn("This is a\nstrong hook", srt_content)
+
+    def test_build_segment_fallback_srt_content_keeps_landscape_lines_wider(self) -> None:
+        srt_content, _ = build_segment_fallback_srt_content(
+            self.score_segments[0],
+            clip_duration_seconds=4.2,
+            export_settings=ExportSettings(),
+        )
+
+        self.assertIn("This is a strong\nhook for a", srt_content)
 
     def test_select_segments_honors_requested_clip_count_and_topic_focus(self) -> None:
         segments = [
@@ -766,6 +806,98 @@ class ClippingServiceTests(unittest.TestCase):
         insert_payload = clips_table.insert.call_args.args[0]
         self.assertEqual(insert_payload[0]["subtitle_text"], "")
         self.assertIsNone(insert_payload[0]["subtitle_url"])
+
+    def test_generate_clips_falls_back_visual_mode_when_stylized_mode_has_no_subtitles(self) -> None:
+        case_dir = self._workspace_case_dir("clipping-stylized-fallback")
+        clips_table = SimpleNamespace(
+            delete=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=MagicMock())))),
+            insert=MagicMock(return_value=SimpleNamespace(execute=MagicMock())),
+        )
+        service_supabase_mock = MagicMock()
+        service_supabase_mock.table.side_effect = lambda name: clips_table if name == "clips" else MagicMock()
+
+        def fake_ffmpeg(*args, **kwargs):
+            clip_path = args[1]
+            clip_path.write_bytes(b"clip")
+
+        with patch.object(clipping_service_module, "service_supabase", service_supabase_mock):
+            with patch.object(clipping_service_module, "GENERATED_CLIPS_ROOT", case_dir / "generated"):
+                with patch.object(clipping_service_module, "_get_podcast_row", return_value={"id": "podcast-123"}):
+                    with patch.object(clipping_service_module, "_resolve_source_media_path", return_value=Path("podcast.mp4")):
+                        with patch.object(clipping_service_module, "_run_ffmpeg_clip_generation", side_effect=fake_ffmpeg):
+                            clips = generate_clips(
+                                "podcast-123",
+                                self.score_segments,
+                                self.transcription,
+                                export_settings=ExportSettingsInput(
+                                    export_mode="portrait",
+                                    crop_mode="smart_crop",
+                                ),
+                                generation_settings=GenerationSettings(subtitles_enabled=False),
+                                visual_output_mode="stylized_animated",
+                            )
+
+        self.assertEqual(len(clips), 1)
+        self.assertEqual(clips[0].visual_output_mode, "stylized_animated")
+        self.assertEqual(clips[0].effective_visual_output_mode, "original_people")
+        self.assertEqual(
+            clips[0].render_fallback_reason,
+            "stylized_animated_requires_subtitles",
+        )
+
+    def test_generate_clips_disables_overlay_rendering_for_book_like_mode(self) -> None:
+        case_dir = self._workspace_case_dir("clipping-book-like-overlay-disabled")
+        delete_execute = MagicMock()
+        insert_execute = MagicMock()
+        clips_table = SimpleNamespace(
+            delete=MagicMock(return_value=SimpleNamespace(eq=MagicMock(return_value=SimpleNamespace(execute=delete_execute)))),
+            insert=MagicMock(return_value=SimpleNamespace(execute=insert_execute)),
+        )
+        service_supabase_mock = MagicMock()
+        service_supabase_mock.table.side_effect = lambda name: clips_table if name == "clips" else MagicMock()
+
+        def fake_ffmpeg(*args, **kwargs):
+            self.assertIsNone(kwargs.get("overlay"))
+            clip_path = args[1]
+            clip_path.write_bytes(b"clip")
+
+        overlay = OverlayDecision(
+            clip_id="clip-1",
+            podcast_id="podcast-123",
+            keyword="ai",
+            overlay_category="technology",
+            overlay_asset="ai_chip",
+            asset_path="technology/ai_chip.png",
+            position="bottom_right",
+            scale=0.2,
+            opacity=0.95,
+            render_start_seconds=0.8,
+            render_end_seconds=2.6,
+            applied=True,
+            render_status="mapped",
+        )
+
+        with patch.object(clipping_service_module, "service_supabase", service_supabase_mock):
+            with patch.object(clipping_service_module, "GENERATED_CLIPS_ROOT", case_dir / "generated"):
+                with patch.object(clipping_service_module, "_get_podcast_row", return_value={"id": "podcast-123"}):
+                    with patch.object(clipping_service_module, "_resolve_source_media_path", return_value=Path("podcast.mp4")):
+                        with patch.object(clipping_service_module, "_run_ffmpeg_clip_generation", side_effect=fake_ffmpeg):
+                            with patch.object(
+                                clipping_service_module.overlay_mapping_service_module,
+                                "detect_overlay_decision",
+                                return_value=overlay,
+                            ):
+                                clips = generate_clips(
+                                    "podcast-123",
+                                    self.score_segments,
+                                    self.transcription,
+                                    visual_output_mode="book_like",
+                                )
+
+        self.assertEqual(len(clips), 1)
+        self.assertIsNotNone(clips[0].overlay)
+        self.assertEqual(clips[0].overlay.render_status, "mode_disabled")
+        self.assertFalse(clips[0].overlay.rendered)
 
     def test_generate_clips_raises_when_segment_has_no_overlapping_words(self) -> None:
         invalid_segment = ScoreSegment(

--- a/backend/tests/test_media_utils.py
+++ b/backend/tests/test_media_utils.py
@@ -78,6 +78,7 @@ class MediaUtilsTests(unittest.TestCase):
         self.assertEqual(contract.height, 1920)
         self.assertEqual(contract.subtitle_timing_profile, "compact")
         self.assertLessEqual(contract.subtitle_timing.max_words_per_cue, 5)
+        self.assertEqual(contract.subtitle_timing.max_lines, 3)
 
     def test_build_render_contract_returns_landscape_contract(self) -> None:
         contract = build_render_contract(
@@ -91,6 +92,39 @@ class MediaUtilsTests(unittest.TestCase):
         self.assertEqual(contract.height, 1080)
         self.assertEqual(contract.subtitle_timing_profile, "extended")
         self.assertGreaterEqual(contract.subtitle_timing.max_duration_seconds, 3.4)
+        self.assertEqual(contract.subtitle_timing.max_lines, 2)
+
+    def test_build_render_contract_switches_book_like_mode_policies(self) -> None:
+        contract = build_render_contract(
+            ExportSettingsInput(export_mode="portrait", crop_mode="smart_crop"),
+            visual_output_mode="book_like",
+            subtitles_available=True,
+            clip_duration_seconds=32.0,
+        )
+
+        self.assertEqual(contract.requested_visual_output_mode, "book_like")
+        self.assertEqual(contract.effective_visual_output_mode, "book_like")
+        self.assertEqual(contract.rendering_profile, "editorial_frame")
+        self.assertEqual(contract.overlay_policy, "disabled")
+        self.assertEqual(contract.subtitle_policy, "narrative_cards")
+        self.assertGreaterEqual(contract.overlay_safe_margin_y, 90)
+
+    def test_build_render_contract_falls_back_stylized_mode_on_landscape(self) -> None:
+        contract = build_render_contract(
+            ExportSettings(),
+            visual_output_mode="stylized_animated",
+            subtitles_available=True,
+            clip_duration_seconds=28.0,
+        )
+
+        self.assertEqual(contract.requested_visual_output_mode, "stylized_animated")
+        self.assertEqual(contract.effective_visual_output_mode, "original_people")
+        self.assertEqual(contract.rendering_profile, "live_action")
+        self.assertEqual(contract.overlay_policy, "full")
+        self.assertEqual(
+            contract.render_fallback_reason,
+            "stylized_animated_requires_portrait_export",
+        )
 
     def test_resolve_export_settings_for_render_tunes_short_portrait_subtitles(self) -> None:
         resolved = resolve_export_settings_for_render(
@@ -116,6 +150,22 @@ class MediaUtilsTests(unittest.TestCase):
 
         self.assertEqual(resolved.subtitle_style.background_opacity, 0)
         self.assertEqual(resolved.subtitle_style.preset, "minimal")
+
+    def test_resolve_export_settings_for_render_tunes_book_like_subtitles(self) -> None:
+        resolved = resolve_export_settings_for_render(
+            ExportSettingsInput(
+                export_mode="portrait",
+                subtitle_style=SubtitleStyle(preset="classic", font_family="Arial", font_size=18),
+            ),
+            visual_output_mode="book_like",
+            subtitles_available=True,
+            clip_duration_seconds=36.0,
+        )
+
+        self.assertEqual(resolved.subtitle_style.font_family, "Georgia")
+        self.assertEqual(resolved.subtitle_style.position, "top")
+        self.assertTrue(resolved.subtitle_style.italic)
+        self.assertGreaterEqual(resolved.subtitle_style.background_opacity, 0.42)
 
     def test_compute_portrait_crop_window_uses_face_center_when_available(self) -> None:
         with patch("app.utils.reframing.read_video_dimensions", return_value=(1920, 1080)):


### PR DESCRIPTION
## What I worked on
My task in Sprint 11 was Job 3: implement the first version of the 3 output modes in the clip rendering pipeline.

## What I did
- Added support for 3 visual output modes:
  - `original_people`
  - `book_like`
  - `stylized_animated`
- Passed mode selection through the backend clip generation and rendering flow.
- Added deterministic render behavior for each mode.
- Added graceful fallback behavior when a mode cannot be fully applied.
- Updated subtitle formatting so subtitles better match the video format/orientation.
- Adjusted overlay and subtitle behavior depending on the selected mode.
- Added backend tests for mode selection, fallback behavior, and subtitle/render formatting.

## Files updated
- `backend/app/models/media.py`
- `backend/app/models/clipping.py`
- `backend/app/services/media_service.py`
- `backend/app/services/clipping_service.py`
- `backend/app/routers/podcasts.py`
- `backend/tests/test_media_utils.py`
- `backend/tests/test_clipping_service.py`

## Testing
- Ran backend unit tests for clipping, media, export settings, and podcast analysis router
- Ran frontend helper/API tests to confirm nothing broke

## Sprint role
My responsibility in this sprint was to build the backend foundation for multiple output styles and prepare the rendering pipeline for future visual expansion.