### PR TITLE
feat: add feedback and content calendar backend

### DIFF
--- a/backend/app/models/profile.py
+++ b/backend/app/models/profile.py
@@ -1,8 +1,13 @@
 from datetime import datetime
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 from app.models.export_settings import ExportSettings, ExportSettingsInput
+
+UserMessageType = Literal["feedback", "support", "contact"]
+UserMessageCategory = Literal["bug", "feature_request", "general", "billing", "technical_support"]
 
 
 class ProfileRecord(BaseModel):
@@ -53,3 +58,43 @@ class UpdateUserExportSettingsRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     export_settings: ExportSettingsInput
+
+
+class UserMessageRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    message_type: UserMessageType = "feedback"
+    category: UserMessageCategory = "general"
+    subject: str | None = Field(default=None, max_length=120)
+    message: str = Field(min_length=10, max_length=2000)
+    contact_email: EmailStr | None = None
+
+    @field_validator("subject")
+    @classmethod
+    def normalize_subject(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = " ".join(value.split())
+        return cleaned or None
+
+    @field_validator("message")
+    @classmethod
+    def normalize_message(cls, value: str) -> str:
+        cleaned = " ".join(value.split())
+        if len(cleaned) < 10:
+            raise ValueError("message must contain at least 10 characters.")
+        return cleaned
+
+
+class UserMessageResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    user_id: str
+    message_type: UserMessageType
+    category: UserMessageCategory
+    subject: str | None = None
+    message: str
+    contact_email: EmailStr | None = None
+    status: Literal["received", "triaged"] = "received"
+    created_at: datetime | None = None

--- a/backend/app/models/publishing.py
+++ b/backend/app/models/publishing.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 PublicationStatus = Literal["pending", "published", "failed"]
 PublicationDestination = Literal["download", "tiktok", "instagram", "youtube", "other"]
+ContentCalendarPlatform = Literal["tiktok", "linkedin", "youtube"]
 
 
 class ClipPublicationStatus(BaseModel):
@@ -141,3 +142,60 @@ class PublishClipRequest(BaseModel):
         if len(value) > 25:
             raise ValueError("metadata cannot contain more than 25 fields.")
         return value
+
+
+class ContentCalendarSuggestion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_id: str
+    clip_number: int = Field(ge=1)
+    platform: ContentCalendarPlatform
+    scheduled_day: int = Field(ge=1, le=14)
+    best_time_local: str
+    title: str
+    caption: str
+    hashtags: list[str] = Field(default_factory=list, max_length=8)
+    call_to_action: str
+    repurpose_angle: str
+
+    @field_validator("clip_id", "best_time_local", "title", "caption", "call_to_action", "repurpose_angle")
+    @classmethod
+    def validate_required_strings(cls, value: str) -> str:
+        cleaned = " ".join(value.split()) if value.strip() else value.strip()
+        if not cleaned:
+            raise ValueError("Field cannot be empty.")
+        return cleaned
+
+    @field_validator("hashtags")
+    @classmethod
+    def normalize_hashtags(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for tag in value:
+            cleaned = tag.strip()
+            if not cleaned:
+                continue
+            if not cleaned.startswith("#"):
+                cleaned = f"#{cleaned}"
+            cleaned = cleaned.replace(" ", "")
+            lowered = cleaned.lower()
+            if lowered not in seen:
+                normalized.append(cleaned)
+                seen.add(lowered)
+        return normalized[:8]
+
+
+class ContentCalendarResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    podcast_id: str
+    total_suggestions: int = Field(ge=0)
+    suggestions: list[ContentCalendarSuggestion] = Field(default_factory=list)
+
+    @field_validator("podcast_id")
+    @classmethod
+    def validate_podcast_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("podcast_id cannot be empty.")
+        return cleaned

--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -10,6 +10,7 @@ from app.models.analysis import AnalysisResult, AnalysisSummary, AnalyzePodcastR
 from app.models.clip_insights import PodcastClipMetrics
 from app.models.clipping import ClipGenerationResult, GenerateClipsRequest
 from app.models.publishing import ClipPublicationResult, PublishClipsRequest
+from app.models.publishing import ContentCalendarResponse
 from app.models.podcast import PodcastsResponse, UserPodcastAnalytics
 from app.models.search import RecommendationResult
 from app.services.analysis_service import (
@@ -38,6 +39,7 @@ from app.services.clipping_service import (
 )
 from app.services.publishing_service import (
     PublishingError,
+    build_content_calendar,
     get_published_clip_download_content,
     publish_clips,
 )
@@ -344,6 +346,22 @@ async def get_podcast_clip_metrics(
     try:
         return get_clip_metrics_for_podcast(podcast_id)
     except ClipInsightsError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+@router.get("/{podcast_id}/content-calendar", response_model=ContentCalendarResponse)
+async def get_podcast_content_calendar(
+    podcast_id: str,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> ContentCalendarResponse:
+    if not podcast_belongs_to_user(podcast_id, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Podcast not found for the current user.",
+        )
+    try:
+        return build_content_calendar(podcast_id)
+    except PublishingError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -6,11 +6,14 @@ from app.models.profile import (
     UpdateProfileRequest,
     UpdateUserExportSettingsRequest,
     UserExportSettingsResponse,
+    UserMessageRequest,
+    UserMessageResponse,
 )
 from app.services.profile_service import (
     get_profile_by_id,
     get_user_export_settings,
     serialize_profile,
+    submit_user_message,
     update_profile,
     update_user_export_settings,
 )
@@ -75,3 +78,66 @@ async def patch_export_settings(
             detail="Profile not found.",
         )
     return update_user_export_settings(current_user.id, payload.export_settings)
+
+
+@router.post("/feedback", response_model=UserMessageResponse, status_code=status.HTTP_201_CREATED)
+async def submit_feedback(
+    payload: UserMessageRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> UserMessageResponse:
+    profile = get_profile_by_id(current_user.id)
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found.",
+        )
+
+    try:
+        return submit_user_message(
+            current_user.id,
+            payload.model_copy(update={"message_type": "feedback"}),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/support", response_model=UserMessageResponse, status_code=status.HTTP_201_CREATED)
+async def submit_support_request(
+    payload: UserMessageRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> UserMessageResponse:
+    profile = get_profile_by_id(current_user.id)
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found.",
+        )
+
+    try:
+        return submit_user_message(
+            current_user.id,
+            payload.model_copy(update={"message_type": "support"}),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/contact", response_model=UserMessageResponse, status_code=status.HTTP_201_CREATED)
+async def submit_contact_message(
+    payload: UserMessageRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> UserMessageResponse:
+    profile = get_profile_by_id(current_user.id)
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found.",
+        )
+
+    try:
+        return submit_user_message(
+            current_user.id,
+            payload.model_copy(update={"message_type": "contact"}),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -372,6 +372,10 @@ def generate_clips(
                     "face_tracking_enabled": clip_export_settings.face_tracking_enabled,
                     "subtitle_style": clip_export_settings.subtitle_style.model_dump(mode="json"),
                     "audio_enhancement": clip_export_settings.audio_enhancement.model_dump(mode="json"),
+                    "generation_settings": resolved_generation_settings.model_dump(mode="json"),
+                    "visual_output_mode": visual_output_mode,
+                    "effective_visual_output_mode": render_contract.effective_visual_output_mode,
+                    "render_fallback_reason": render_contract.render_fallback_reason,
                 }
             )
         except ClippingError as exc:
@@ -448,6 +452,12 @@ def get_clips_for_podcast(podcast_id: str) -> ClipGenerationResult | None:
             published_at=row.get("published_at"),
             overlay=overlays_by_clip_id.get(str(row["id"])),
             export_settings=_build_export_settings_from_row(row),
+            generation_settings=GenerationSettings.model_validate(
+                row.get("generation_settings") or {}
+            ),
+            visual_output_mode=str(row.get("visual_output_mode") or "original_people"),  # type: ignore[arg-type]
+            effective_visual_output_mode=str(row.get("effective_visual_output_mode") or row.get("visual_output_mode") or "original_people"),  # type: ignore[arg-type]
+            render_fallback_reason=str(row.get("render_fallback_reason") or "").strip() or None,
         )
         for row in rows
     ]
@@ -1404,6 +1414,7 @@ def _build_export_settings_from_row(row: dict[str, Any]) -> ExportSettings:
         face_tracking_enabled=bool(row.get("face_tracking_enabled") or False),
         subtitle_style=row.get("subtitle_style") or SubtitleStyle(),
         audio_enhancement=row.get("audio_enhancement") or {},
+        generation_settings=row.get("generation_settings") or {},
     )
 
 
@@ -1437,7 +1448,7 @@ def _select_clip_rows_for_podcast(podcast_id: str) -> Any:
         return (
             service_supabase.table("clips")
             .select(
-                "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,preset_name,export_mode,crop_mode,subtitle_timing_profile,mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement"
+                "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,storage_path,storage_url,subtitle_text,status,published,download_url,published_at,preset_name,export_mode,crop_mode,subtitle_timing_profile,mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement,generation_settings,visual_output_mode,effective_visual_output_mode,render_fallback_reason"
             )
             .eq("podcast_id", podcast_id)
             .order("clip_number")
@@ -1494,6 +1505,10 @@ def _clip_optional_columns_missing(exc: Exception) -> bool:
             "face_tracking_enabled",
             "subtitle_style",
             "audio_enhancement",
+            "generation_settings",
+            "visual_output_mode",
+            "effective_visual_output_mode",
+            "render_fallback_reason",
             "42703",
         )
     )

--- a/backend/app/services/profile_service.py
+++ b/backend/app/services/profile_service.py
@@ -1,6 +1,12 @@
 from app.database import service_supabase
 from app.models.export_settings import ExportSettings, ExportSettingsInput
-from app.models.profile import ProfileRecord, ProfileResponse, UserExportSettingsResponse
+from app.models.profile import (
+    ProfileRecord,
+    ProfileResponse,
+    UserExportSettingsResponse,
+    UserMessageRequest,
+    UserMessageResponse,
+)
 
 PROFILE_COLUMNS = "id,email,free_trial_used,full_name,profile_picture_url,export_settings,created_at,updated_at"
 
@@ -119,6 +125,39 @@ def update_user_export_settings(
     return UserExportSettingsResponse(
         user_id=profile.id,
         export_settings=profile.export_settings,
+    )
+
+
+def submit_user_message(profile_id: str, payload: UserMessageRequest) -> UserMessageResponse:
+    cleaned_profile_id = profile_id.strip()
+    if not cleaned_profile_id:
+        raise ValueError("Profile id is required.")
+
+    record = {
+        "user_id": cleaned_profile_id,
+        "message_type": payload.message_type,
+        "category": payload.category,
+        "subject": payload.subject,
+        "message": payload.message,
+        "contact_email": str(payload.contact_email) if payload.contact_email else None,
+        "status": "received",
+    }
+    response = service_supabase.table("user_messages").insert(record).execute()
+    rows = response.data or []
+    if not rows:
+        raise ValueError("Unable to submit message.")
+
+    row = rows[0]
+    return UserMessageResponse(
+        id=str(row.get("id") or ""),
+        user_id=str(row.get("user_id") or cleaned_profile_id),
+        message_type=row.get("message_type") or payload.message_type,
+        category=row.get("category") or payload.category,
+        subject=row.get("subject"),
+        message=str(row.get("message") or payload.message),
+        contact_email=row.get("contact_email"),
+        status=row.get("status") or "received",
+        created_at=row.get("created_at"),
     )
 
 

--- a/backend/app/services/publishing_service.py
+++ b/backend/app/services/publishing_service.py
@@ -12,6 +12,8 @@ from app.models.publishing import (
     ClipPublicationStatus,
     ClipPublicationStatusResponse,
     ClipRevocationResult,
+    ContentCalendarResponse,
+    ContentCalendarSuggestion,
     PublicationDestination,
 )
 from app.services.clipping_service import CLIP_STORAGE_BUCKET, _upload_with_overwrite
@@ -311,6 +313,57 @@ def get_clip_metrics(clip_id: str) -> ClipMetricResponse | None:
     )
 
 
+def build_content_calendar(
+    podcast_id: str,
+    *,
+    days: int = 7,
+    max_clips: int = 5,
+) -> ContentCalendarResponse:
+    cleaned_podcast_id = podcast_id.strip()
+    if not cleaned_podcast_id:
+        raise PublishingError("podcast_id is required.", status_code=400)
+    if days < 1 or days > 14:
+        raise PublishingError("days must be between 1 and 14.", status_code=400)
+    if max_clips < 1 or max_clips > 10:
+        raise PublishingError("max_clips must be between 1 and 10.", status_code=400)
+    if isinstance(service_supabase, UnconfiguredSupabaseClient):
+        raise PublishingError("Supabase must be configured before content calendars can be generated.", status_code=503)
+
+    rows = _get_calendar_clip_rows(cleaned_podcast_id)
+    ready_rows = [
+        row
+        for row in rows
+        if str(row.get("status") or "ready").strip().lower() in {"ready", "done", "completed"}
+    ]
+    ranked_rows = sorted(
+        ready_rows,
+        key=lambda row: (
+            -float(row.get("virality_score") or 0.0),
+            int(row.get("clip_number") or 0),
+            str(row.get("id") or ""),
+        ),
+    )[:max_clips]
+
+    suggestions: list[ContentCalendarSuggestion] = []
+    platforms = ("tiktok", "linkedin", "youtube")
+    for clip_index, row in enumerate(ranked_rows):
+        for platform_index, platform in enumerate(platforms):
+            scheduled_day = ((clip_index + platform_index) % days) + 1
+            suggestions.append(
+                _build_calendar_suggestion(
+                    row,
+                    platform=platform,
+                    scheduled_day=scheduled_day,
+                )
+            )
+
+    return ContentCalendarResponse(
+        podcast_id=cleaned_podcast_id,
+        total_suggestions=len(suggestions),
+        suggestions=suggestions,
+    )
+
+
 def _normalize_clip_ids(clip_ids: list[str]) -> list[str]:
     normalized: list[str] = []
     seen: set[str] = set()
@@ -342,6 +395,133 @@ def _select_clip_rows():
     return service_supabase.table("clips").select(
         "id,podcast_id,clip_number,storage_path,storage_url,status,published,download_url,published_at"
     )
+
+
+def _get_calendar_clip_rows(podcast_id: str) -> list[dict[str, Any]]:
+    return (
+        service_supabase.table("clips")
+        .select("id,podcast_id,clip_number,subtitle_text,virality_score,status,published,published_at")
+        .eq("podcast_id", podcast_id)
+        .execute()
+        .data
+        or []
+    )
+
+
+def _build_calendar_suggestion(
+    row: dict[str, Any],
+    *,
+    platform: str,
+    scheduled_day: int,
+) -> ContentCalendarSuggestion:
+    clip_number = int(row.get("clip_number") or 0)
+    subtitle = _normalize_calendar_text(str(row.get("subtitle_text") or ""))
+    title_seed = subtitle or f"Clip {clip_number}"
+    title = _truncate_words(title_seed, 9)
+    angle = _platform_angle(platform, subtitle)
+    return ContentCalendarSuggestion(
+        clip_id=str(row.get("id") or ""),
+        clip_number=clip_number,
+        platform=platform,  # type: ignore[arg-type]
+        scheduled_day=scheduled_day,
+        best_time_local=_platform_best_time(platform),
+        title=_platform_title(platform, title),
+        caption=_platform_caption(platform, title_seed),
+        hashtags=_platform_hashtags(platform, subtitle),
+        call_to_action=_platform_cta(platform),
+        repurpose_angle=angle,
+    )
+
+
+def _normalize_calendar_text(value: str) -> str:
+    return " ".join(value.split()).strip()
+
+
+def _truncate_words(value: str, limit: int) -> str:
+    words = _normalize_calendar_text(value).split()
+    if not words:
+        return "Generated clip"
+    shortened = " ".join(words[:limit])
+    return shortened if len(words) <= limit else f"{shortened}..."
+
+
+def _platform_best_time(platform: str) -> str:
+    return {
+        "tiktok": "19:30",
+        "linkedin": "09:00",
+        "youtube": "17:00",
+    }.get(platform, "12:00")
+
+
+def _platform_title(platform: str, title: str) -> str:
+    if platform == "linkedin":
+        return f"Insight: {title}"
+    if platform == "youtube":
+        return f"{title} | Podcast Clip"
+    return title
+
+
+def _platform_caption(platform: str, subtitle: str) -> str:
+    seed = _truncate_words(subtitle, 18)
+    if platform == "linkedin":
+        return f"{seed}\n\nA concise takeaway from the full conversation."
+    if platform == "youtube":
+        return f"{seed}\n\nWatch this highlight and save the full episode for later."
+    return f"{seed} Watch until the end for the key takeaway."
+
+
+def _platform_cta(platform: str) -> str:
+    return {
+        "tiktok": "Follow for more short podcast takeaways.",
+        "linkedin": "Comment with the takeaway you would apply first.",
+        "youtube": "Subscribe for more clips from this podcast.",
+    }.get(platform, "Save this clip for later.")
+
+
+def _platform_angle(platform: str, subtitle: str) -> str:
+    if platform == "linkedin":
+        return "Frame the clip as a professional lesson or discussion prompt."
+    if platform == "youtube":
+        return "Package the clip as a searchable highlight from the episode."
+    if "?" in subtitle:
+        return "Open with the question and let the answer drive retention."
+    return "Lead with the strongest hook in the first two seconds."
+
+
+def _platform_hashtags(platform: str, subtitle: str) -> list[str]:
+    base = {
+        "tiktok": ["#PodcastClips", "#CreatorTips", "#InsightClips"],
+        "linkedin": ["#Leadership", "#ContentStrategy", "#Podcast"],
+        "youtube": ["#Podcast", "#Shorts", "#Highlights"],
+    }.get(platform, ["#Podcast"])
+    keyword_tags = [
+        f"#{word.title()}"
+        for word in _extract_calendar_keywords(subtitle)
+        if len(word) > 3
+    ]
+    return [*base, *keyword_tags][:6]
+
+
+def _extract_calendar_keywords(subtitle: str) -> list[str]:
+    blocked = {
+        "this",
+        "that",
+        "with",
+        "from",
+        "your",
+        "have",
+        "will",
+        "about",
+        "into",
+        "they",
+        "them",
+    }
+    words: list[str] = []
+    for raw_word in subtitle.lower().replace("?", " ").replace(".", " ").replace(",", " ").split():
+        cleaned = "".join(character for character in raw_word if character.isalnum())
+        if cleaned and cleaned not in blocked and cleaned not in words:
+            words.append(cleaned)
+    return words[:3]
 
 
 def _persist_publication_record(

--- a/backend/sql/auth_schema.sql
+++ b/backend/sql/auth_schema.sql
@@ -1,5 +1,18 @@
 alter table public.profiles
-  add column if not exists export_settings jsonb not null default '{"export_mode":"landscape","crop_mode":"none","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}}'::jsonb;
+  add column if not exists export_settings jsonb not null default '{"export_mode":"landscape","crop_mode":"none","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"},"generation_settings":{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}}'::jsonb;
+
+update public.profiles
+set export_settings =
+  (
+    '{"export_mode":"landscape","crop_mode":"none","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"},"generation_settings":{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}}'::jsonb
+    || coalesce(export_settings, '{}'::jsonb)
+  )
+  || jsonb_build_object(
+    'generation_settings',
+    '{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}'::jsonb
+      || coalesce(export_settings -> 'generation_settings', '{}'::jsonb)
+  )
+where jsonb_typeof(export_settings) = 'object';
 
 alter table public.profiles
   drop constraint if exists profiles_export_settings_check;
@@ -19,4 +32,101 @@ alter table public.profiles
     and jsonb_typeof(export_settings -> 'subtitle_style') = 'object'
     and export_settings ? 'audio_enhancement'
     and jsonb_typeof(export_settings -> 'audio_enhancement') = 'object'
+    and export_settings ? 'generation_settings'
+    and jsonb_typeof(export_settings -> 'generation_settings') = 'object'
   );
+
+create table if not exists public.user_messages (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  message_type text not null default 'feedback',
+  category text not null default 'general',
+  subject text,
+  message text not null,
+  contact_email text,
+  status text not null default 'received',
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+alter table public.user_messages
+  drop constraint if exists user_messages_message_type_check;
+
+alter table public.user_messages
+  add constraint user_messages_message_type_check check (
+    message_type in ('feedback', 'support', 'contact')
+  );
+
+alter table public.user_messages
+  drop constraint if exists user_messages_category_check;
+
+alter table public.user_messages
+  add constraint user_messages_category_check check (
+    category in ('bug', 'feature_request', 'general', 'billing', 'technical_support')
+  );
+
+alter table public.user_messages
+  drop constraint if exists user_messages_status_check;
+
+alter table public.user_messages
+  add constraint user_messages_status_check check (
+    status in ('received', 'triaged')
+  );
+
+alter table public.user_messages
+  drop constraint if exists user_messages_message_length_check;
+
+alter table public.user_messages
+  add constraint user_messages_message_length_check check (
+    length(trim(message)) between 10 and 2000
+  );
+
+create index if not exists user_messages_user_id_created_at_idx
+  on public.user_messages (user_id, created_at desc);
+
+alter table public.user_messages enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'user_messages'
+      and policyname = 'Users can submit own messages'
+  ) then
+    create policy "Users can submit own messages"
+      on public.user_messages
+      for insert
+      to authenticated
+      with check (user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'user_messages'
+      and policyname = 'Users can view own messages'
+  ) then
+    create policy "Users can view own messages"
+      on public.user_messages
+      for select
+      to authenticated
+      using (user_id = auth.uid());
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'user_messages'
+      and policyname = 'Service role manages user messages'
+  ) then
+    create policy "Service role manages user messages"
+      on public.user_messages
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end $$;

--- a/backend/sql/clips_schema.sql
+++ b/backend/sql/clips_schema.sql
@@ -18,6 +18,35 @@ create table if not exists public.clips (
 create index if not exists clips_podcast_id_idx on public.clips (podcast_id);
 create unique index if not exists clips_podcast_clip_number_idx on public.clips (podcast_id, clip_number);
 
+alter table public.clips
+  add column if not exists generation_settings jsonb not null default '{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}'::jsonb,
+  add column if not exists visual_output_mode text not null default 'original_people',
+  add column if not exists effective_visual_output_mode text not null default 'original_people',
+  add column if not exists render_fallback_reason text;
+
+alter table public.clips
+  drop constraint if exists clips_generation_settings_check;
+
+alter table public.clips
+  add constraint clips_generation_settings_check check (
+    jsonb_typeof(generation_settings) = 'object'
+    and generation_settings ? 'clip_duration_seconds'
+    and (generation_settings ->> 'clip_duration_seconds')::integer between 8 and 90
+    and generation_settings ? 'number_of_clips'
+    and (generation_settings ->> 'number_of_clips')::integer between 1 and 10
+    and generation_settings ? 'subtitles_enabled'
+    and jsonb_typeof(generation_settings -> 'subtitles_enabled') = 'boolean'
+  );
+
+alter table public.clips
+  drop constraint if exists clips_visual_output_mode_check;
+
+alter table public.clips
+  add constraint clips_visual_output_mode_check check (
+    visual_output_mode in ('original_people', 'book_like', 'stylized_animated')
+    and effective_visual_output_mode in ('original_people', 'book_like', 'stylized_animated')
+  );
+
 alter table public.clips enable row level security;
 
 do $$

--- a/backend/sql/export_settings_schema.sql
+++ b/backend/sql/export_settings_schema.sql
@@ -9,7 +9,20 @@ alter table public.podcasts
   add column if not exists audio_enhancement jsonb not null default '{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}'::jsonb;
 
 alter table public.profiles
-  add column if not exists export_settings jsonb not null default '{"preset_name":"youtube_landscape","export_mode":"landscape","crop_mode":"none","subtitle_timing_profile":"extended","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"}}'::jsonb;
+  add column if not exists export_settings jsonb not null default '{"preset_name":"youtube_landscape","export_mode":"landscape","crop_mode":"none","subtitle_timing_profile":"extended","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"},"generation_settings":{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}}'::jsonb;
+
+update public.profiles
+set export_settings =
+  (
+    '{"preset_name":"youtube_landscape","export_mode":"landscape","crop_mode":"none","subtitle_timing_profile":"extended","mobile_optimized":false,"face_tracking_enabled":false,"subtitle_style":{"preset":"classic","font_family":"Arial","font_size":18,"primary_color":"#FFFFFF","outline_color":"#000000","background_color":"#000000","background_opacity":0.2,"position":"bottom","bold":false,"italic":false},"audio_enhancement":{"enabled":true,"normalize_loudness":true,"target_lufs":-16.0,"true_peak_db":-1.5,"status":"enabled"},"generation_settings":{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}}'::jsonb
+    || coalesce(export_settings, '{}'::jsonb)
+  )
+  || jsonb_build_object(
+    'generation_settings',
+    '{"clip_duration_seconds":30,"number_of_clips":5,"topic_focus":null,"subtitles_enabled":true}'::jsonb
+      || coalesce(export_settings -> 'generation_settings', '{}'::jsonb)
+  )
+where jsonb_typeof(export_settings) = 'object';
 
 alter table public.podcasts
   drop constraint if exists podcasts_preset_name_check;

--- a/backend/tests/test_clipping_service.py
+++ b/backend/tests/test_clipping_service.py
@@ -844,6 +844,14 @@ class ClippingServiceTests(unittest.TestCase):
             clips[0].render_fallback_reason,
             "stylized_animated_requires_subtitles",
         )
+        insert_payload = clips_table.insert.call_args.args[0]
+        self.assertEqual(insert_payload[0]["generation_settings"]["subtitles_enabled"], False)
+        self.assertEqual(insert_payload[0]["visual_output_mode"], "stylized_animated")
+        self.assertEqual(insert_payload[0]["effective_visual_output_mode"], "original_people")
+        self.assertEqual(
+            insert_payload[0]["render_fallback_reason"],
+            "stylized_animated_requires_subtitles",
+        )
 
     def test_generate_clips_disables_overlay_rendering_for_book_like_mode(self) -> None:
         case_dir = self._workspace_case_dir("clipping-book-like-overlay-disabled")

--- a/backend/tests/test_profile_service.py
+++ b/backend/tests/test_profile_service.py
@@ -12,7 +12,8 @@ if str(BACKEND_ROOT) not in sys.path:
 
 import app.services.profile_service as profile_service_module  # noqa: E402
 from app.models.export_settings import ExportSettingsInput  # noqa: E402
-from app.services.profile_service import update_profile, update_user_export_settings  # noqa: E402
+from app.models.profile import UserMessageRequest  # noqa: E402
+from app.services.profile_service import submit_user_message, update_profile, update_user_export_settings  # noqa: E402
 
 
 class ProfileServiceTests(unittest.TestCase):
@@ -140,6 +141,88 @@ class ProfileServiceTests(unittest.TestCase):
         self.assertEqual(response.export_settings.export_mode, "portrait")
         update_payload = update_mock.call_args.args[0]
         self.assertEqual(update_payload["export_settings"]["crop_mode"], "center_crop")
+
+    def test_submit_user_message_persists_feedback_request(self) -> None:
+        service_supabase_mock = MagicMock()
+        execute_mock = MagicMock(
+            return_value=SimpleNamespace(
+                data=[
+                    {
+                        "id": "message-1",
+                        "user_id": "user-123",
+                        "message_type": "feedback",
+                        "category": "feature_request",
+                        "subject": "Calendar",
+                        "message": "Please add a better weekly planning flow.",
+                        "contact_email": "creator@example.com",
+                        "status": "received",
+                        "created_at": None,
+                    }
+                ]
+            )
+        )
+        insert_mock = MagicMock(return_value=SimpleNamespace(execute=execute_mock))
+        table_mock = MagicMock(return_value=SimpleNamespace(insert=insert_mock))
+        service_supabase_mock.table = table_mock
+
+        payload = UserMessageRequest(
+            message_type="feedback",
+            category="feature_request",
+            subject="  Calendar  ",
+            message=" Please add a better weekly planning flow. ",
+            contact_email="creator@example.com",
+        )
+
+        with patch.object(profile_service_module, "service_supabase", service_supabase_mock):
+            response = submit_user_message("user-123", payload)
+
+        self.assertEqual(response.id, "message-1")
+        self.assertEqual(response.category, "feature_request")
+        self.assertEqual(response.subject, "Calendar")
+        insert_payload = insert_mock.call_args.args[0]
+        self.assertEqual(insert_payload["user_id"], "user-123")
+        self.assertEqual(insert_payload["message"], "Please add a better weekly planning flow.")
+    
+    def test_submit_user_message_persists_contact_request(self) -> None:
+        service_supabase_mock = MagicMock()
+        execute_mock = MagicMock(
+            return_value=SimpleNamespace(
+                data=[
+                    {
+                        "id": "message-2",
+                        "user_id": "user-123",
+                        "message_type": "contact",
+                        "category": "general",
+                        "subject": "Partnership",
+                        "message": "I want to contact the InsightClips team.",
+                        "contact_email": "creator@example.com",
+                        "status": "received",
+                        "created_at": None,
+                    }
+                ]
+            )
+        )
+        insert_mock = MagicMock(return_value=SimpleNamespace(execute=execute_mock))
+        service_supabase_mock.table = MagicMock(return_value=SimpleNamespace(insert=insert_mock))
+
+        payload = UserMessageRequest(
+            message_type="contact",
+            category="general",
+            subject="Partnership",
+            message="I want to contact the InsightClips team.",
+            contact_email="creator@example.com",
+        )
+
+        with patch.object(profile_service_module, "service_supabase", service_supabase_mock):
+            response = submit_user_message("user-123", payload)
+
+        self.assertEqual(response.message_type, "contact")
+        self.assertEqual(response.contact_email, "creator@example.com")
+        self.assertEqual(insert_mock.call_args.args[0]["message_type"], "contact")
+
+    def test_user_message_request_rejects_short_messages(self) -> None:
+        with self.assertRaises(ValueError):
+            UserMessageRequest(message="short")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_publishing_routes.py
+++ b/backend/tests/test_publishing_routes.py
@@ -22,6 +22,8 @@ from app.models.publishing import (  # noqa: E402
     ClipPublicationStatus,
     ClipPublicationStatusResponse,
     ClipRevocationResult,
+    ContentCalendarResponse,
+    ContentCalendarSuggestion,
     PublishClipRequest,
     PublishClipsRequest,
 )
@@ -31,7 +33,7 @@ from app.routers.clips import (
     publish_clip_route,
     revoke_clip_download_route,
 )  # noqa: E402
-from app.routers.podcasts import download_generated_clip, publish_podcast_clips  # noqa: E402
+from app.routers.podcasts import download_generated_clip, get_podcast_content_calendar, publish_podcast_clips  # noqa: E402
 
 
 class PublishingRouterTests(unittest.TestCase):
@@ -110,6 +112,53 @@ class PublishingRouterTests(unittest.TestCase):
         self.assertEqual(exc_info.exception.status_code, 404)
         podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
         publish_clips_mock.assert_not_called()
+
+    @patch("app.routers.podcasts.build_content_calendar")
+    @patch("app.routers.podcasts.podcast_belongs_to_user", return_value=True)
+    def test_content_calendar_route_returns_owned_planning_data(
+        self,
+        podcast_belongs_mock,
+        build_content_calendar_mock,
+    ) -> None:
+        build_content_calendar_mock.return_value = ContentCalendarResponse(
+            podcast_id="podcast-123",
+            total_suggestions=1,
+            suggestions=[
+                ContentCalendarSuggestion(
+                    clip_id="clip-1",
+                    clip_number=1,
+                    platform="tiktok",
+                    scheduled_day=1,
+                    best_time_local="19:30",
+                    title="Strong hook",
+                    caption="Strong hook Watch until the end.",
+                    hashtags=["#PodcastClips"],
+                    call_to_action="Follow for more short podcast takeaways.",
+                    repurpose_angle="Lead with the strongest hook in the first two seconds.",
+                )
+            ],
+        )
+
+        result = asyncio.run(get_podcast_content_calendar("podcast-123", self.user))
+
+        self.assertEqual(result.total_suggestions, 1)
+        self.assertEqual(result.suggestions[0].platform, "tiktok")
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        build_content_calendar_mock.assert_called_once_with("podcast-123")
+
+    @patch("app.routers.podcasts.build_content_calendar")
+    @patch("app.routers.podcasts.podcast_belongs_to_user", return_value=False)
+    def test_content_calendar_route_rejects_unowned_podcast(
+        self,
+        podcast_belongs_mock,
+        build_content_calendar_mock,
+    ) -> None:
+        with self.assertRaises(HTTPException) as exc_info:
+            asyncio.run(get_podcast_content_calendar("podcast-123", self.user))
+
+        self.assertEqual(exc_info.exception.status_code, 404)
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        build_content_calendar_mock.assert_not_called()
 
     def test_publish_request_rejects_blank_clip_ids(self) -> None:
         with self.assertRaises(ValidationError):

--- a/backend/tests/test_publishing_service.py
+++ b/backend/tests/test_publishing_service.py
@@ -19,6 +19,7 @@ from app.services.publishing_service import (  # noqa: E402
     get_clip_metrics,
     get_clip_publication_status,
     get_published_clip_download_content,
+    build_content_calendar,
     publish_clips,
     revoke_clip_download,
 )
@@ -434,6 +435,50 @@ class PublishingServiceTests(unittest.TestCase):
         self.assertIsNone(content)
         self.assertIsNone(file_path)
         self.assertIsNone(filename)
+
+    def test_build_content_calendar_returns_platform_specific_suggestions(self) -> None:
+        case_dir = self._workspace_case_dir("publishing-calendar")
+        rows = self._build_clip_rows(case_dir)
+        rows.append(
+            {
+                "id": "clip-2",
+                "podcast_id": "podcast-123",
+                "clip_number": 2,
+                "subtitle_text": "How leaders turn audience trust into consistent growth",
+                "status": "ready",
+                "virality_score": 94.0,
+                "published": False,
+                "published_at": None,
+            }
+        )
+        storage = FakeStorage()
+        fake_supabase = FakeSupabase(rows, storage)
+
+        with patch.object(publishing_service_module, "service_supabase", fake_supabase):
+            result = build_content_calendar("podcast-123", days=7, max_clips=2)
+
+        self.assertEqual(result.podcast_id, "podcast-123")
+        self.assertEqual(result.total_suggestions, 6)
+        self.assertEqual(
+            [suggestion.platform for suggestion in result.suggestions[:3]],
+            ["tiktok", "linkedin", "youtube"],
+        )
+        self.assertEqual(result.suggestions[0].clip_id, "clip-2")
+        self.assertIn("#PodcastClips", result.suggestions[0].hashtags)
+        self.assertEqual(result.suggestions[1].best_time_local, "09:00")
+
+    def test_build_content_calendar_rejects_invalid_days(self) -> None:
+        case_dir = self._workspace_case_dir("publishing-calendar-invalid")
+        rows = self._build_clip_rows(case_dir)
+        storage = FakeStorage()
+        fake_supabase = FakeSupabase(rows, storage)
+
+        with patch.object(publishing_service_module, "service_supabase", fake_supabase):
+            with self.assertRaises(PublishingError) as exc_info:
+                build_content_calendar("podcast-123", days=30)
+
+        self.assertEqual(exc_info.exception.status_code, 400)
+        self.assertIn("days", exc_info.exception.detail)
 
 
 if __name__ == "__main__":

--- a/frontend/app/clips/page.tsx
+++ b/frontend/app/clips/page.tsx
@@ -39,6 +39,7 @@ import {
   type GenerationTemplateId,
   type Podcast,
   type PodcastsResponse,
+  type VisualOutputMode,
 } from "@/lib/api";
 import {
   applyGenerationTemplate,
@@ -106,6 +107,36 @@ const FILTERS: Array<{ value: ClipStatusFilter; label: string }> = [
   { value: "ready", label: "Ready" },
   { value: "processing", label: "Processing" },
   { value: "failed", label: "Failed" },
+];
+
+const VISUAL_OUTPUT_MODES: Array<{
+  value: VisualOutputMode;
+  label: string;
+  title: string;
+  description: string;
+  badge: string;
+}> = [
+  {
+    value: "original_people",
+    label: "Original People",
+    title: "Keep the talking-head video",
+    description: "Preserves the source footage with subtitles and overlays rendered in the normal clip style.",
+    badge: "Default",
+  },
+  {
+    value: "book_like",
+    label: "Book Like",
+    title: "Editorial reading frame",
+    description: "Uses a quieter subtitle rhythm and disables overlays so the clip feels more like a sourced explainer.",
+    badge: "Editorial",
+  },
+  {
+    value: "stylized_animated",
+    label: "Stylized Animated",
+    title: "Motion-forward social style",
+    description: "Tuned for portrait output with stronger captions and limited overlays for a more animated presentation.",
+    badge: "Portrait",
+  },
 ];
 
 function formatTime(seconds: number): string {
@@ -309,6 +340,8 @@ function ClipsPageContent() {
   );
   const [generationExportSettings, setGenerationExportSettings] =
     useState<ExportSettings | null>(null);
+  const [visualOutputMode, setVisualOutputMode] =
+    useState<VisualOutputMode>("original_people");
 
   const t = dark ? T.dark : T.light;
   const isMobile = viewportWidth < 960;
@@ -599,6 +632,33 @@ function ClipsPageContent() {
     setGenerationExportSettings(next.exportSettings);
   };
 
+  const handleVisualOutputModeChange = (mode: VisualOutputMode) => {
+    setVisualOutputMode(mode);
+    if (mode === "stylized_animated") {
+      setGenerationExportSettings((current) => ({
+        ...normalizeExportSettings(current ?? selectedPodcast?.export_settings ?? null),
+        export_mode: "portrait",
+        crop_mode: "smart_crop",
+        mobile_optimized: true,
+        face_tracking_enabled: true,
+      }));
+      setGenerationSettings((current) =>
+        normalizeGenerationSettings({
+          ...current,
+          subtitles_enabled: true,
+        }),
+      );
+    }
+    if (mode === "book_like") {
+      setGenerationSettings((current) =>
+        normalizeGenerationSettings({
+          ...current,
+          subtitles_enabled: true,
+        }),
+      );
+    }
+  };
+
   const handleSubtitleStyleChange = (
     changes: Partial<
       Pick<
@@ -641,6 +701,7 @@ function ClipsPageContent() {
           export_settings:
             generationExportSettings ??
             normalizeExportSettings(selectedPodcast?.export_settings ?? null),
+          visual_output_mode: visualOutputMode,
           save_generation_settings: true,
           use_preferred_generation_settings: true,
         },
@@ -1375,6 +1436,146 @@ function ClipsPageContent() {
                   hi2: t.accentLt,
                 }}
               />
+
+              <section
+                className="glass a2"
+                style={{
+                  borderRadius: 22,
+                  border: `1px solid ${t.border}`,
+                  background: dark ? "rgba(14,24,11,.88)" : "rgba(255,255,255,.9)",
+                  padding: "24px 24px 22px",
+                  marginBottom: 16,
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 16,
+                    flexWrap: "wrap",
+                    marginBottom: 16,
+                  }}
+                >
+                  <div>
+                    <div
+                      style={{
+                        fontSize: 10,
+                        letterSpacing: ".26em",
+                        textTransform: "uppercase",
+                        color: t.accentLt,
+                        fontWeight: 700,
+                        marginBottom: 8,
+                      }}
+                    >
+                      Visual output mode
+                    </div>
+                    <h2
+                      style={{
+                        fontFamily: "'DM Serif Display',serif",
+                        fontStyle: "italic",
+                        fontSize: 24,
+                        fontWeight: 400,
+                        marginBottom: 10,
+                      }}
+                    >
+                      Choose how the rendered clip should feel
+                    </h2>
+                    <p style={{ fontSize: 13, color: t.textSub, lineHeight: 1.72, maxWidth: 620 }}>
+                      The mode is sent with generation and controls overlay, subtitle, and fallback behavior in the render pipeline.
+                    </p>
+                  </div>
+                  <div
+                    style={{
+                      borderRadius: 999,
+                      border: `1px solid ${t.borderSub}`,
+                      background: dark ? "rgba(90,158,58,.12)" : "rgba(90,158,58,.08)",
+                      padding: "8px 12px",
+                      color: t.accent,
+                      fontSize: 11,
+                      fontWeight: 800,
+                    }}
+                  >
+                    {VISUAL_OUTPUT_MODES.find((mode) => mode.value === visualOutputMode)?.label}
+                  </div>
+                </div>
+
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit,minmax(210px,1fr))",
+                    gap: 10,
+                  }}
+                >
+                  {VISUAL_OUTPUT_MODES.map((mode) => {
+                    const active = visualOutputMode === mode.value;
+                    return (
+                      <button
+                        key={mode.value}
+                        type="button"
+                        onClick={() => handleVisualOutputModeChange(mode.value)}
+                        style={{
+                          textAlign: "left",
+                          borderRadius: 18,
+                          padding: "16px 16px 15px",
+                          border: `1px solid ${active ? t.accent : t.borderSub}`,
+                          background: active
+                            ? dark
+                              ? "rgba(90,158,58,.16)"
+                              : "rgba(90,158,58,.1)"
+                            : dark
+                              ? "rgba(11,18,9,.55)"
+                              : "rgba(248,252,245,.82)",
+                          color: t.text,
+                          cursor: "pointer",
+                        }}
+                      >
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            gap: 10,
+                            marginBottom: 10,
+                          }}
+                        >
+                          <div
+                            style={{
+                              fontSize: 10,
+                              fontWeight: 800,
+                              letterSpacing: ".16em",
+                              textTransform: "uppercase",
+                              color: active ? t.accent : t.accentLt,
+                            }}
+                          >
+                            {mode.label}
+                          </div>
+                          <span
+                            style={{
+                              borderRadius: 999,
+                              border: `1px solid ${active ? "rgba(255,255,255,.22)" : t.borderSub}`,
+                              padding: "4px 8px",
+                              fontSize: 9,
+                              fontWeight: 800,
+                              letterSpacing: ".14em",
+                              textTransform: "uppercase",
+                              color: active ? t.accent : t.textSub,
+                            }}
+                          >
+                            {mode.badge}
+                          </span>
+                        </div>
+                        <div style={{ fontSize: 13, fontWeight: 800, marginBottom: 6 }}>
+                          {mode.title}
+                        </div>
+                        <div style={{ fontSize: 12, lineHeight: 1.6, color: t.textSub }}>
+                          {mode.description}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
 
               <SubtitleStylePanel
                 dark={dark}

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -71,7 +71,11 @@ const EXPORT_MODE_DETAILS: Record<
   },
 };
 
-function buildExportSettings(exportMode: ExportMode, subtitleStyle: SubtitleStyle): ExportSettings {
+function buildExportSettings(
+  exportMode: ExportMode,
+  subtitleStyle: SubtitleStyle,
+  generationSettings?: GenerationSettings,
+): ExportSettings {
   if (exportMode === "portrait") {
     return {
       export_mode: "portrait",
@@ -79,6 +83,7 @@ function buildExportSettings(exportMode: ExportMode, subtitleStyle: SubtitleStyl
       mobile_optimized: true,
       face_tracking_enabled: true,
       subtitle_style: subtitleStyle,
+      generation_settings: generationSettings,
       audio_enhancement: DEFAULT_AUDIO_ENHANCEMENT,
     };
   }
@@ -89,6 +94,7 @@ function buildExportSettings(exportMode: ExportMode, subtitleStyle: SubtitleStyl
     mobile_optimized: false,
     face_tracking_enabled: false,
     subtitle_style: subtitleStyle,
+    generation_settings: generationSettings,
     audio_enhancement: DEFAULT_AUDIO_ENHANCEMENT,
   };
 }
@@ -257,8 +263,8 @@ export default function UploadPage() {
   const hi2     = "#7ab55c";
   const exportDetails = EXPORT_MODE_DETAILS[exportMode];
   const exportSettings = useMemo(
-    () => buildExportSettings(exportMode, subtitleStyle),
-    [exportMode, subtitleStyle],
+    () => buildExportSettings(exportMode, subtitleStyle, generationSettings),
+    [exportMode, subtitleStyle, generationSettings],
   );
   const activeSubtitlePreset = SUBTITLE_PRESET_DETAILS[subtitleStyle.preset];
   const subtitleHasManualOverrides = hasSubtitleManualOverrides(subtitleStyle);
@@ -375,7 +381,7 @@ export default function UploadPage() {
   const selectGenerationTemplate = (templateId: GenerationTemplateId) => {
     const next = applyGenerationTemplate(
       templateId,
-      buildExportSettings(exportMode, subtitleStyle),
+      buildExportSettings(exportMode, subtitleStyle, generationSettings),
     );
     setGenerationTemplateId(templateId);
     setGenerationSettings(next.generationSettings);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -35,6 +35,7 @@ export type CropMode = "none" | "center_crop" | "smart_crop";
 export type SubtitleStylePreset = "classic" | "bold" | "minimal" | "boxed";
 export type SubtitlePosition = "top" | "center" | "bottom";
 export type GenerationTemplateId = "hook_spotlight" | "story_arc" | "expert_take";
+export type VisualOutputMode = "original_people" | "book_like" | "stylized_animated";
 
 export type SubtitleStyle = {
   preset: SubtitleStylePreset;
@@ -77,6 +78,7 @@ export type GenerationSettings = {
 export type GenerateClipsPayload = {
   generation_settings?: GenerationSettings;
   export_settings?: ExportSettings;
+  visual_output_mode?: VisualOutputMode;
   save_generation_settings?: boolean;
   use_preferred_generation_settings?: boolean;
 };
@@ -264,6 +266,9 @@ export type ClipResult = {
   overlay?: ClipOverlay | null;
   export_settings?: ExportSettings | null;
   generation_settings?: GenerationSettings | null;
+  visual_output_mode?: VisualOutputMode | null;
+  effective_visual_output_mode?: VisualOutputMode | null;
+  render_fallback_reason?: string | null;
 };
 
 export type ClipGenerationResult = {
@@ -675,6 +680,9 @@ export async function generateClips(
   }
   if (payload?.export_settings) {
     requestBody.export_settings = payload.export_settings;
+  }
+  if (payload?.visual_output_mode) {
+    requestBody.visual_output_mode = payload.visual_output_mode;
   }
   if (typeof payload?.save_generation_settings === "boolean") {
     requestBody.save_generation_settings = payload.save_generation_settings;

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -528,6 +528,7 @@ async function testGenerateClipsPostsGenerationSettingsPayload(): Promise<void> 
           topic_focus: "Prioritize strong opening hooks.",
           subtitles_enabled: true,
         },
+        visual_output_mode: "stylized_animated",
         save_generation_settings: true,
         use_preferred_generation_settings: true,
         export_settings: {
@@ -563,6 +564,7 @@ async function testGenerateClipsPostsGenerationSettingsPayload(): Promise<void> 
           topic_focus: "Prioritize strong opening hooks.",
           subtitles_enabled: true,
         },
+        visual_output_mode: "stylized_animated",
         save_generation_settings: true,
         use_preferred_generation_settings: true,
         export_settings: {


### PR DESCRIPTION
## Summary
- Added protected feedback, support, and contact message endpoints
- Added backend content calendar suggestions for TikTok, LinkedIn, and YouTube
- Added structured planning response models and service logic
- Added Supabase schema support for user messages and planning-related data
- Added tests for valid/invalid submission flows and protected planning output

## Tests
- python -m unittest discover backend\tests
- npm test -- --runInBand