### PR TITLE
feat: add Sprint 13 YouTube import backend flow

### DIFF
--- a/backend/app/models/podcast.py
+++ b/backend/app/models/podcast.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.export_settings import ExportSettings
@@ -14,6 +16,10 @@ class PodcastRecord(BaseModel):
     duration: int
     status: str
     storage_path: str | None = None
+    source_type: str = "upload"
+    source_url: str | None = None
+    external_source_id: str | None = None
+    import_metadata: dict[str, Any] = Field(default_factory=dict)
     export_settings: ExportSettings | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -26,6 +32,10 @@ class PodcastResponse(BaseModel):
     duration: int
     status: str
     storage_path: str | None = None
+    source_type: str = "upload"
+    source_url: str | None = None
+    external_source_id: str | None = None
+    import_metadata: dict[str, Any] = Field(default_factory=dict)
     export_settings: ExportSettings | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/backend/app/models/upload.py
+++ b/backend/app/models/upload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -105,4 +105,45 @@ class UploadPrepareResponse(BaseModel):
     payment_status: str
     price: float
     currency: str = "USD"
+    export_settings: ExportSettings | None = None
+
+
+class YouTubeImportRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    url: str
+    title: str | None = None
+    export_settings: ExportSettingsInput | None = None
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("YouTube URL cannot be empty.")
+        return cleaned
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        cleaned = " ".join(value.split())
+        if not cleaned:
+            raise ValueError("Field cannot be empty.")
+        return cleaned
+
+
+class YouTubeImportResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    podcast_id: str
+    status: UploadStatus
+    source_type: Literal["youtube"] = "youtube"
+    source_url: str
+    video_id: str
+    title: str
+    storage_path: str
+    duration_seconds: float
+    metadata: dict[str, Any] = Field(default_factory=dict)
     export_settings: ExportSettings | None = None

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -6,8 +6,15 @@ from app.models.upload import (
     UploadCalculatePriceResponse,
     UploadPrepareRequest,
     UploadPrepareResponse,
+    YouTubeImportRequest,
+    YouTubeImportResponse,
 )
-from app.services.upload_service import UploadWorkflowError, calculate_upload_price, prepare_upload
+from app.services.upload_service import (
+    UploadWorkflowError,
+    calculate_upload_price,
+    import_youtube_podcast,
+    prepare_upload,
+)
 from app.utils.media import MediaInspectionError
 
 router = APIRouter(prefix="/upload", tags=["upload"])
@@ -35,5 +42,16 @@ async def prepare_upload_route(
         return prepare_upload(payload, current_user)
     except MediaInspectionError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except UploadWorkflowError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+@router.post("/youtube", response_model=YouTubeImportResponse)
+async def import_youtube_route(
+    payload: YouTubeImportRequest,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> YouTubeImportResponse:
+    try:
+        return import_youtube_podcast(payload, current_user)
     except UploadWorkflowError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc

--- a/backend/app/services/podcast_service.py
+++ b/backend/app/services/podcast_service.py
@@ -12,7 +12,8 @@ from app.models.podcast import (
 
 PODCAST_COLUMNS = (
     "id,user_id,title,duration,status,storage_path,export_mode,crop_mode,"
-    "mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement,created_at,updated_at"
+    "mobile_optimized,face_tracking_enabled,subtitle_style,audio_enhancement,"
+    "source_type,source_url,external_source_id,import_metadata,created_at,updated_at"
 )
 CLIP_ANALYTICS_COLUMNS_WITH_METRICS = (
     "id,podcast_id,clip_number,clip_start_sec,clip_end_sec,virality_score,status,"
@@ -51,8 +52,40 @@ def _build_export_settings(row: dict[str, object]) -> ExportSettings:
 
 def _serialize_podcast_row(row: dict[str, object]) -> dict[str, object]:
     payload = dict(row)
+    payload.setdefault("source_type", "upload")
+    payload.setdefault("import_metadata", {})
     payload["export_settings"] = _build_export_settings(payload)
     return payload
+
+
+def create_imported_podcast_record(payload: dict[str, object]) -> str:
+    try:
+        response = service_supabase.table("podcasts").insert(payload).execute()
+    except Exception as exc:
+        if not _optional_podcast_columns_missing(exc):
+            raise
+        fallback_payload = dict(payload)
+        for key in (
+            "preset_name",
+            "export_mode",
+            "crop_mode",
+            "subtitle_timing_profile",
+            "mobile_optimized",
+            "face_tracking_enabled",
+            "subtitle_style",
+            "audio_enhancement",
+            "source_type",
+            "source_url",
+            "external_source_id",
+            "import_metadata",
+        ):
+            fallback_payload.pop(key, None)
+        response = service_supabase.table("podcasts").insert(fallback_payload).execute()
+
+    rows = response.data or []
+    if not rows:
+        raise RuntimeError("Podcast record could not be created.")
+    return str(rows[0]["id"])
 
 
 def get_podcasts_for_user(user_id: str) -> tuple[list[PodcastResponse], bool]:
@@ -161,7 +194,7 @@ def _select_podcast_rows_for_user(user_id: str):
             .execute()
         )
     except Exception as exc:
-        if not _podcast_export_columns_missing(exc):
+        if not _optional_podcast_columns_missing(exc):
             raise
         return (
             service_supabase.table("podcasts")
@@ -183,7 +216,7 @@ def _select_podcast_row_for_user(podcast_id: str, user_id: str):
             .execute()
         )
     except Exception as exc:
-        if not _podcast_export_columns_missing(exc):
+        if not _optional_podcast_columns_missing(exc):
             raise
         return (
             service_supabase.table("podcasts")
@@ -312,3 +345,25 @@ def _podcast_export_columns_missing(exc: Exception) -> bool:
             "42703",
         )
     )
+
+
+def _podcast_source_columns_missing(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(
+        token in message
+        for token in (
+            "source_type",
+            "source_url",
+            "external_source_id",
+            "import_metadata",
+            "column podcasts.source_type does not exist",
+            "column podcasts.source_url does not exist",
+            "column podcasts.external_source_id does not exist",
+            "column podcasts.import_metadata does not exist",
+            "42703",
+        )
+    )
+
+
+def _optional_podcast_columns_missing(exc: Exception) -> bool:
+    return _podcast_export_columns_missing(exc) or _podcast_source_columns_missing(exc)

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+import re
 
 from app.database import service_supabase
 from app.dependencies.auth import AuthenticatedUser
@@ -11,9 +15,12 @@ from app.models.upload import (
     UploadPrepareResponse,
     UploadPreflightStatus,
     UploadStatus,
+    YouTubeImportRequest,
+    YouTubeImportResponse,
 )
 from app.models.export_settings import ExportSettings
 from app.services.media_service import inspect_staged_media
+from app.services.podcast_service import create_imported_podcast_record
 from app.services.profile_service import get_profile_by_id, mark_free_trial_used
 from app.utils.media import validate_media_type
 
@@ -23,6 +30,15 @@ MAX_UPLOAD_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024
 SHORT_UPLOAD_PRICE = 1.0
 MEDIUM_UPLOAD_PRICE = 2.0
 LONG_UPLOAD_PRICE = 4.0
+YOUTUBE_IMPORT_DIR = Path(".generated") / "youtube-imports"
+YOUTUBE_VIDEO_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{11}$")
+YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+}
 
 
 class UploadWorkflowError(Exception):
@@ -39,6 +55,25 @@ class UploadPriceDecision:
     price: float
     free_trial_available: bool
     message: str
+
+
+@dataclass(frozen=True)
+class YouTubeSource:
+    original_url: str
+    normalized_url: str
+    video_id: str
+
+
+@dataclass(frozen=True)
+class YouTubeDownloadResult:
+    title: str
+    storage_path: str
+    duration_seconds: float
+    filename: str
+    filesize_bytes: int | None
+    mime_type: str
+    detected_format: str
+    metadata: dict[str, Any]
 
 
 def _get_latest_free_trial_state(current_user: AuthenticatedUser) -> bool:
@@ -154,6 +189,209 @@ def calculate_upload_price(
         detected_format=detected_format,
         validation_flags=validation_flags,
     )
+
+
+def parse_youtube_source(url: str) -> YouTubeSource:
+    cleaned_url = url.strip()
+    parsed = urlparse(cleaned_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise UploadWorkflowError(
+            "Only http or https YouTube URLs are supported.",
+            status_code=400,
+            code="invalid_youtube_url",
+        )
+
+    host = (parsed.hostname or "").lower()
+    if host not in YOUTUBE_HOSTS:
+        raise UploadWorkflowError(
+            "Only youtube.com or youtu.be links are supported.",
+            status_code=400,
+            code="unsupported_youtube_source",
+        )
+
+    query = parse_qs(parsed.query)
+    if "list" in query:
+        raise UploadWorkflowError(
+            "Playlist import is not supported. Submit a single YouTube video link.",
+            status_code=400,
+            code="playlist_not_supported",
+        )
+
+    video_id = ""
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if host == "youtu.be":
+        video_id = path_parts[0] if path_parts else ""
+    elif path_parts[:1] == ["watch"]:
+        video_id = (query.get("v") or [""])[0]
+    elif path_parts and path_parts[0] in {"shorts", "embed", "live"}:
+        video_id = path_parts[1] if len(path_parts) > 1 else ""
+
+    if not YOUTUBE_VIDEO_ID_PATTERN.fullmatch(video_id):
+        raise UploadWorkflowError(
+            "A valid single-video YouTube URL is required.",
+            status_code=400,
+            code="invalid_youtube_video_id",
+        )
+
+    return YouTubeSource(
+        original_url=cleaned_url,
+        normalized_url=f"https://www.youtube.com/watch?v={video_id}",
+        video_id=video_id,
+    )
+
+
+def import_youtube_podcast(
+    payload: YouTubeImportRequest,
+    current_user: AuthenticatedUser,
+) -> YouTubeImportResponse:
+    source = parse_youtube_source(payload.url)
+    resolved_export_settings = payload.export_settings.resolve() if payload.export_settings else ExportSettings()
+    download_result = _download_youtube_media(source, current_user.id)
+    title = payload.title or download_result.title
+
+    insert_payload = _build_youtube_podcast_insert_payload(
+        current_user,
+        source,
+        download_result,
+        title=title,
+        export_settings=resolved_export_settings,
+    )
+
+    try:
+        podcast_id = create_imported_podcast_record(insert_payload)
+    except Exception as exc:
+        raise UploadWorkflowError("YouTube import could not be saved.", status_code=500) from exc
+
+    return YouTubeImportResponse(
+        podcast_id=podcast_id,
+        status="ready_for_processing",
+        source_url=source.normalized_url,
+        video_id=source.video_id,
+        title=title,
+        storage_path=download_result.storage_path,
+        duration_seconds=download_result.duration_seconds,
+        metadata=download_result.metadata,
+        export_settings=resolved_export_settings,
+    )
+
+
+def _download_youtube_media(source: YouTubeSource, user_id: str) -> YouTubeDownloadResult:
+    try:
+        from yt_dlp import YoutubeDL
+    except ImportError as exc:
+        raise UploadWorkflowError(
+            "YouTube import requires the yt-dlp package to be installed.",
+            status_code=503,
+            code="youtube_downloader_unavailable",
+        ) from exc
+
+    target_dir = YOUTUBE_IMPORT_DIR / _safe_path_part(user_id)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    output_template = str(target_dir / f"{source.video_id}.%(ext)s")
+    options = {
+        "format": "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/best",
+        "merge_output_format": "mp4",
+        "noplaylist": True,
+        "outtmpl": output_template,
+        "quiet": True,
+        "no_warnings": True,
+    }
+
+    try:
+        with YoutubeDL(options) as downloader:
+            info = downloader.extract_info(source.normalized_url, download=True)
+            requested_downloads = info.get("requested_downloads") or []
+            downloaded_path = ""
+            for item in requested_downloads:
+                downloaded_path = str(item.get("filepath") or item.get("_filename") or "")
+                if downloaded_path:
+                    break
+            if not downloaded_path:
+                downloaded_path = str(info.get("filepath") or downloader.prepare_filename(info))
+    except Exception as exc:
+        raise UploadWorkflowError(
+            "YouTube media could not be imported. Check that the video is public and try again.",
+            status_code=502,
+            code="youtube_import_failed",
+        ) from exc
+
+    media_path = Path(downloaded_path)
+    if not media_path.exists() and media_path.suffix != ".mp4":
+        mp4_candidate = media_path.with_suffix(".mp4")
+        if mp4_candidate.exists():
+            media_path = mp4_candidate
+
+    if not media_path.exists():
+        raise UploadWorkflowError(
+            "YouTube import finished without a staged media file.",
+            status_code=502,
+            code="youtube_import_missing_file",
+        )
+
+    duration_seconds = float(info.get("duration") or 0.0)
+    if duration_seconds <= 0:
+        inspection = inspect_staged_media(str(media_path), filename=media_path.name, mime_type="video/mp4")
+        duration_seconds = inspection.duration_seconds
+        detected_format = inspection.detected_format
+    else:
+        detected_format = media_path.suffix.lstrip(".").lower() or "mp4"
+
+    metadata = {
+        "original_url": source.original_url,
+        "normalized_url": source.normalized_url,
+        "webpage_url": info.get("webpage_url") or source.normalized_url,
+        "channel": info.get("channel") or info.get("uploader"),
+        "duration_seconds": round(duration_seconds, 2),
+    }
+    return YouTubeDownloadResult(
+        title=str(info.get("title") or f"YouTube video {source.video_id}"),
+        storage_path=str(media_path),
+        duration_seconds=round(duration_seconds, 2),
+        filename=media_path.name,
+        filesize_bytes=media_path.stat().st_size,
+        mime_type="video/mp4",
+        detected_format=detected_format,
+        metadata={key: value for key, value in metadata.items() if value is not None},
+    )
+
+
+def _build_youtube_podcast_insert_payload(
+    current_user: AuthenticatedUser,
+    source: YouTubeSource,
+    download_result: YouTubeDownloadResult,
+    *,
+    title: str,
+    export_settings: ExportSettings,
+) -> dict[str, Any]:
+    return {
+        "user_id": current_user.id,
+        "title": title,
+        "duration": round(download_result.duration_seconds),
+        "status": "ready_for_processing",
+        "price": 0.0,
+        "payment_status": "not_required",
+        "source_filename": download_result.filename,
+        "storage_path": download_result.storage_path,
+        "mime_type": download_result.mime_type,
+        "detected_format": download_result.detected_format,
+        "source_type": "youtube",
+        "source_url": source.normalized_url,
+        "external_source_id": source.video_id,
+        "import_metadata": download_result.metadata,
+        "preset_name": export_settings.preset_name,
+        "export_mode": export_settings.export_mode,
+        "crop_mode": export_settings.crop_mode,
+        "subtitle_timing_profile": export_settings.subtitle_timing_profile,
+        "mobile_optimized": export_settings.mobile_optimized,
+        "face_tracking_enabled": export_settings.face_tracking_enabled,
+        "subtitle_style": export_settings.subtitle_style.model_dump(mode="json"),
+        "audio_enhancement": export_settings.audio_enhancement.model_dump(mode="json"),
+    }
+
+
+def _safe_path_part(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+    return cleaned.strip(".-") or "user"
 
 
 def _assert_prepare_matches_quote(

--- a/backend/sql/schema_init.sql
+++ b/backend/sql/schema_init.sql
@@ -27,7 +27,11 @@ alter table if exists public.podcasts
   add column if not exists storage_path text,
   add column if not exists source_filename text,
   add column if not exists mime_type text,
-  add column if not exists detected_format text;
+  add column if not exists detected_format text,
+  add column if not exists source_type text not null default 'upload',
+  add column if not exists source_url text,
+  add column if not exists external_source_id text,
+  add column if not exists import_metadata jsonb not null default '{}'::jsonb;
 
 alter table if exists public.podcasts
   drop constraint if exists podcasts_price_check;
@@ -49,6 +53,14 @@ alter table if exists public.podcasts
 alter table if exists public.podcasts
   add constraint podcasts_payment_status_check check (
     payment_status in ('pending', 'paid', 'not_required', 'failed')
+  );
+
+alter table if exists public.podcasts
+  drop constraint if exists podcasts_source_type_check;
+
+alter table if exists public.podcasts
+  add constraint podcasts_source_type_check check (
+    source_type in ('upload', 'youtube')
   );
 
 alter table public.profiles enable row level security;

--- a/backend/tests/test_podcast_service.py
+++ b/backend/tests/test_podcast_service.py
@@ -13,6 +13,7 @@ if str(BACKEND_ROOT) not in sys.path:
 import app.services.podcast_service as podcast_service_module  # noqa: E402
 from app.database import UnconfiguredSupabaseClient  # noqa: E402
 from app.services.podcast_service import (  # noqa: E402
+    create_imported_podcast_record,
     get_podcasts_for_user,
     get_user_podcast_analytics,
     update_podcast_status_for_user,
@@ -98,6 +99,65 @@ class PodcastServiceTests(unittest.TestCase):
 
         self.assertTrue(is_mock)
         self.assertGreaterEqual(len(podcasts), 1)
+
+    def test_create_imported_podcast_record_persists_source_metadata(self) -> None:
+        service_supabase_mock = MagicMock()
+        execute_mock = MagicMock(return_value=SimpleNamespace(data=[{"id": "pod-youtube"}]))
+        insert_mock = MagicMock(return_value=SimpleNamespace(execute=execute_mock))
+        table_mock = MagicMock(return_value=SimpleNamespace(insert=insert_mock))
+        service_supabase_mock.table = table_mock
+
+        payload = {
+            "user_id": "user-123",
+            "title": "Imported Episode",
+            "duration": 120,
+            "status": "ready_for_processing",
+            "price": 0.0,
+            "payment_status": "not_required",
+            "storage_path": ".generated/youtube-imports/user-123/video.mp4",
+            "source_type": "youtube",
+            "source_url": "https://www.youtube.com/watch?v=abcDEF123_4",
+            "external_source_id": "abcDEF123_4",
+            "import_metadata": {"channel": "Insight Lab"},
+        }
+
+        with patch.object(podcast_service_module, "service_supabase", service_supabase_mock):
+            podcast_id = create_imported_podcast_record(payload)
+
+        self.assertEqual(podcast_id, "pod-youtube")
+        insert_payload = insert_mock.call_args.args[0]
+        self.assertEqual(insert_payload["source_type"], "youtube")
+        self.assertEqual(insert_payload["external_source_id"], "abcDEF123_4")
+
+    def test_create_imported_podcast_record_falls_back_when_source_columns_are_missing(self) -> None:
+        service_supabase_mock = MagicMock()
+        first_execute = MagicMock(side_effect=RuntimeError("column podcasts.source_type does not exist"))
+        second_execute = MagicMock(return_value=SimpleNamespace(data=[{"id": "pod-fallback"}]))
+        first_insert = MagicMock(return_value=SimpleNamespace(execute=first_execute))
+        second_insert = MagicMock(return_value=SimpleNamespace(execute=second_execute))
+        table_mock = MagicMock()
+        table_mock.return_value.insert.side_effect = [first_insert.return_value, second_insert.return_value]
+        service_supabase_mock.table = table_mock
+
+        payload = {
+            "user_id": "user-123",
+            "title": "Imported Episode",
+            "duration": 120,
+            "status": "ready_for_processing",
+            "storage_path": ".generated/youtube-imports/user-123/video.mp4",
+            "source_type": "youtube",
+            "source_url": "https://www.youtube.com/watch?v=abcDEF123_4",
+            "external_source_id": "abcDEF123_4",
+            "import_metadata": {"channel": "Insight Lab"},
+        }
+
+        with patch.object(podcast_service_module, "service_supabase", service_supabase_mock):
+            podcast_id = create_imported_podcast_record(payload)
+
+        self.assertEqual(podcast_id, "pod-fallback")
+        fallback_payload = table_mock.return_value.insert.call_args_list[1].args[0]
+        self.assertNotIn("source_type", fallback_payload)
+        self.assertNotIn("import_metadata", fallback_payload)
 
     def test_update_podcast_status_for_user_returns_none_when_update_raises(self) -> None:
         service_supabase_mock = MagicMock()

--- a/backend/tests/test_upload_router.py
+++ b/backend/tests/test_upload_router.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.dependencies.auth import AuthenticatedUser  # noqa: E402
+from app.models.upload import YouTubeImportRequest, YouTubeImportResponse  # noqa: E402
+from app.routers.upload import import_youtube_route  # noqa: E402
+from app.services.upload_service import UploadWorkflowError  # noqa: E402
+
+
+class UploadRouterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.user = AuthenticatedUser(
+            id="user-123",
+            email="rinesa@example.com",
+            free_trial_used=False,
+        )
+
+    @patch("app.routers.upload.import_youtube_podcast")
+    def test_import_youtube_route_accepts_processing_request(self, import_mock) -> None:
+        import_mock.return_value = YouTubeImportResponse(
+            podcast_id="pod-youtube",
+            status="ready_for_processing",
+            source_url="https://www.youtube.com/watch?v=abcDEF123_4",
+            video_id="abcDEF123_4",
+            title="Imported Episode",
+            storage_path=".generated/youtube-imports/user-123/abcDEF123_4.mp4",
+            duration_seconds=180.0,
+            metadata={"channel": "Insight Lab"},
+        )
+
+        result = asyncio.run(
+            import_youtube_route(
+                YouTubeImportRequest(url="https://youtu.be/abcDEF123_4"),
+                self.user,
+            )
+        )
+
+        self.assertEqual(result.podcast_id, "pod-youtube")
+        self.assertEqual(result.status, "ready_for_processing")
+        self.assertEqual(result.source_type, "youtube")
+        import_mock.assert_called_once()
+
+    @patch("app.routers.upload.import_youtube_podcast")
+    def test_import_youtube_route_returns_clear_http_error(self, import_mock) -> None:
+        import_mock.side_effect = UploadWorkflowError(
+            "Playlist import is not supported. Submit a single YouTube video link.",
+            status_code=400,
+            code="playlist_not_supported",
+        )
+
+        with self.assertRaises(HTTPException) as error:
+            asyncio.run(
+                import_youtube_route(
+                    YouTubeImportRequest(url="https://www.youtube.com/watch?v=abcDEF123_4"),
+                    self.user,
+                )
+            )
+
+        self.assertEqual(error.exception.status_code, 400)
+        self.assertEqual(
+            error.exception.detail,
+            "Playlist import is not supported. Submit a single YouTube video link.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_upload_service.py
+++ b/backend/tests/test_upload_service.py
@@ -12,11 +12,15 @@ if str(BACKEND_ROOT) not in sys.path:
 
 from app.dependencies.auth import AuthenticatedUser  # noqa: E402
 from app.models.media import MediaInspectionResult  # noqa: E402
-from app.models.upload import UploadCalculatePriceRequest, UploadPrepareRequest  # noqa: E402
+from app.models.upload import UploadCalculatePriceRequest, UploadPrepareRequest, YouTubeImportRequest  # noqa: E402
 import app.services.upload_service as upload_service_module  # noqa: E402
 from app.services.upload_service import (  # noqa: E402
+    UploadWorkflowError,
+    YouTubeDownloadResult,
     calculate_upload_price,
     determine_upload_price,
+    import_youtube_podcast,
+    parse_youtube_source,
     prepare_upload,
 )
 
@@ -171,6 +175,78 @@ class UploadServiceTests(unittest.TestCase):
         self.assertEqual(response.export_settings.crop_mode, "center_crop")
         self.assertEqual(response.export_settings.subtitle_style.preset, "boxed")
         self.assertEqual(response.export_settings.audio_enhancement.true_peak_db, -1.0)
+
+    def test_parse_youtube_source_accepts_single_video_links(self) -> None:
+        watch_source = parse_youtube_source("https://www.youtube.com/watch?v=abcDEF123_4")
+        short_source = parse_youtube_source("https://youtu.be/abcDEF123_4")
+
+        self.assertEqual(watch_source.video_id, "abcDEF123_4")
+        self.assertEqual(watch_source.normalized_url, "https://www.youtube.com/watch?v=abcDEF123_4")
+        self.assertEqual(short_source.normalized_url, watch_source.normalized_url)
+
+    def test_parse_youtube_source_rejects_playlist_and_non_youtube_hosts(self) -> None:
+        with self.assertRaises(UploadWorkflowError) as playlist_error:
+            parse_youtube_source("https://www.youtube.com/watch?v=abcDEF123_4&list=PL123")
+
+        with self.assertRaises(UploadWorkflowError) as host_error:
+            parse_youtube_source("https://example.com/watch?v=abcDEF123_4")
+
+        self.assertEqual(playlist_error.exception.code, "playlist_not_supported")
+        self.assertEqual(host_error.exception.code, "unsupported_youtube_source")
+
+    def test_import_youtube_podcast_creates_ready_processing_record(self) -> None:
+        download_result = YouTubeDownloadResult(
+            title="Imported Founder Interview",
+            storage_path=".generated/youtube-imports/user-123/abcDEF123_4.mp4",
+            duration_seconds=182.4,
+            filename="abcDEF123_4.mp4",
+            filesize_bytes=2048,
+            mime_type="video/mp4",
+            detected_format="mp4",
+            metadata={
+                "channel": "Insight Lab",
+                "normalized_url": "https://www.youtube.com/watch?v=abcDEF123_4",
+            },
+        )
+
+        with patch.object(upload_service_module, "_download_youtube_media", return_value=download_result):
+            with patch.object(upload_service_module, "create_imported_podcast_record", return_value="pod-youtube") as create_mock:
+                response = import_youtube_podcast(
+                    YouTubeImportRequest(
+                        url="https://www.youtube.com/watch?v=abcDEF123_4",
+                        title="Custom Import Title",
+                    ),
+                    self.user,
+                )
+
+        self.assertEqual(response.podcast_id, "pod-youtube")
+        self.assertEqual(response.status, "ready_for_processing")
+        self.assertEqual(response.source_type, "youtube")
+        self.assertEqual(response.video_id, "abcDEF123_4")
+        self.assertEqual(response.title, "Custom Import Title")
+        insert_payload = create_mock.call_args.args[0]
+        self.assertEqual(insert_payload["source_type"], "youtube")
+        self.assertEqual(insert_payload["source_url"], "https://www.youtube.com/watch?v=abcDEF123_4")
+        self.assertEqual(insert_payload["external_source_id"], "abcDEF123_4")
+        self.assertEqual(insert_payload["storage_path"], download_result.storage_path)
+        self.assertEqual(insert_payload["status"], "ready_for_processing")
+        self.assertEqual(insert_payload["payment_status"], "not_required")
+        self.assertEqual(insert_payload["import_metadata"]["channel"], "Insight Lab")
+
+    def test_import_youtube_podcast_surfaces_download_failure(self) -> None:
+        with patch.object(
+            upload_service_module,
+            "_download_youtube_media",
+            side_effect=UploadWorkflowError("failed", status_code=502, code="youtube_import_failed"),
+        ):
+            with self.assertRaises(UploadWorkflowError) as error:
+                import_youtube_podcast(
+                    YouTubeImportRequest(url="https://www.youtube.com/watch?v=abcDEF123_4"),
+                    self.user,
+                )
+
+        self.assertEqual(error.exception.status_code, 502)
+        self.assertEqual(error.exception.code, "youtube_import_failed")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ openai-whisper>=20231117
 ffmpeg-python>=0.2.0
 opencv-python-headless>=4.10.0
 supabase>=2.3.0
+yt-dlp>=2025.1.15


### PR DESCRIPTION
Implemented Sprint 13 Job 1 for YouTube podcast import.

This adds a new backend flow where users can submit a single YouTube video link and the system imports it as a podcast ready for the normal processing pipeline.

What was added:
- New protected endpoint: POST /upload/youtube
- YouTube URL validation for youtube.com and youtu.be links
- Clear rejection for invalid URLs, playlists, and unsupported sources
- YouTube media import support using yt-dlp
- Podcast creation with status ready_for_processing
- Metadata tracking for source_type, source_url, external_source_id, and import_metadata
- Database schema updates for YouTube source tracking
- Unit tests for valid imports, invalid URLs, failure handling, metadata persistence, and router/API behavior

This does not add playlist import or bulk channel ingestion, matching the Sprint 13 Job 1 non-goals.

Verification completed:
- python -m unittest discover backend\tests -p "test_*.py"
- python -m compileall backend\app