### PR TITLE
fix: stabilize upload flow and allow partial clip regenerationTest render fix

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -25,7 +26,7 @@ class Settings(BaseSettings):
     app_name: str = "InsightClips"
     app_version: str = "1.0.0"
     environment: str = "development"
-    frontend_origins: list[str] = Field(
+    frontend_origins: Any = Field(
         default_factory=lambda: [
             "http://localhost:3000",
             "http://127.0.0.1:3000",
@@ -41,7 +42,13 @@ class Settings(BaseSettings):
             if not cleaned:
                 return []
             if cleaned.startswith("["):
-                return value
+                import json
+                try:
+                    parsed = json.loads(cleaned)
+                    if isinstance(parsed, list):
+                        return [str(item).strip() for item in parsed]
+                except Exception:
+                    pass
             return [origin.strip() for origin in cleaned.split(",") if origin.strip()]
         return value
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -58,15 +58,23 @@ def close_db_pool() -> None:
         db_pool.close()
 
 def run_db_healthcheck() -> bool:
-    if not db_pool:
-        return False
-    try:
-        with connect(settings.database_url, autocommit=True, connect_timeout=3) as connection:
-            with connection.cursor() as cursor:
-                cursor.execute("select 1;")
-                return cursor.fetchone() == (1,)
-    except Exception:
-        return False
+    if db_pool:
+        try:
+            with connect(settings.database_url, autocommit=True, connect_timeout=3) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute("select 1;")
+                    return cursor.fetchone() == (1,)
+        except Exception:
+            pass
+
+    if settings.supabase_url and (settings.supabase_service_role_key or settings.supabase_anon_key):
+        try:
+            service_supabase.table("profiles").select("id").limit(1).execute()
+            return True
+        except Exception:
+            pass
+
+    return False
 
 @asynccontextmanager
 async def lifespan(_: object) -> Iterator[None]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,19 @@
+import os
 from pathlib import Path
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
 BACKEND_DIR = Path(__file__).resolve().parent.parent
 ROOT_DIR = BACKEND_DIR.parent
+
+# Add the bin directory to PATH for ffmpeg and ffprobe
+bin_dir = ROOT_DIR / "bin"
+if bin_dir.exists():
+    os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+else:
+    bin_dir_backend = BACKEND_DIR / "bin"
+    if bin_dir_backend.exists():
+        os.environ["PATH"] = str(bin_dir_backend) + os.pathsep + os.environ.get("PATH", "")
 
 load_dotenv(ROOT_DIR / ".env.local")
 load_dotenv(ROOT_DIR / ".env")

--- a/backend/app/routers/podcasts.py
+++ b/backend/app/routers/podcasts.py
@@ -239,11 +239,6 @@ async def generate_podcast_clips(
     _assert_podcast_can_process(podcast_id, current_user.id)
 
     existing_result = get_clips_for_podcast(podcast_id)
-    if existing_result is not None and existing_result.clips:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Clips have already been generated for this podcast. Review the existing clips instead of generating them again.",
-        )
 
     preferred_export_settings = (
         get_user_export_settings(current_user.id)
@@ -261,6 +256,15 @@ async def generate_podcast_clips(
         else None
     )
     generation_settings = payload.resolve_generation_settings(preferred_generation_settings)
+    if (
+        existing_result is not None
+        and existing_result.clips
+        and len(existing_result.clips) >= generation_settings.number_of_clips
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Clips have already been generated for this podcast. Review the existing clips instead of generating them again.",
+        )
     if payload.save_generation_settings and preferred_export_settings is not None:
         update_user_export_settings(
             current_user.id,

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException
+import shutil
+import tempfile
+from pathlib import Path
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from pydantic import BaseModel
 
 from app.dependencies.auth import AuthenticatedUser, get_current_user
 from app.models.upload import (
@@ -14,10 +18,54 @@ from app.services.upload_service import (
     calculate_upload_price,
     import_youtube_podcast,
     prepare_upload,
+    _safe_path_part,
 )
 from app.utils.media import MediaInspectionError
 
 router = APIRouter(prefix="/upload", tags=["upload"])
+
+
+class UploadFileResponse(BaseModel):
+    storage_path: str
+    filename: str
+    filesize_bytes: int
+
+
+def get_upload_dir() -> Path:
+    """Get persistent upload directory for Render."""
+    try:
+        # Use temp directory on Render
+        temp_dir = Path(tempfile.gettempdir()) / "insightclips-uploads"
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        return temp_dir
+    except Exception:
+        # Fallback to .generated for development
+        upload_dir = Path(".") / ".generated" / "uploads"
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        return upload_dir
+
+
+@router.post("/file", response_model=UploadFileResponse)
+async def upload_file(
+    file: UploadFile = File(...),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+) -> UploadFileResponse:
+    try:
+        upload_base = get_upload_dir()
+        target_dir = upload_base / _safe_path_part(current_user.id)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        
+        target_path = target_dir / file.filename
+        with target_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+            
+        return UploadFileResponse(
+            storage_path=str(target_path),
+            filename=file.filename,
+            filesize_bytes=target_path.stat().st_size
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to save uploaded file: {str(exc)}")
 
 
 @router.post("/calculate-price", response_model=UploadCalculatePriceResponse)

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 import re
+import tempfile
 
 from app.database import service_supabase
 from app.dependencies.auth import AuthenticatedUser
@@ -30,7 +31,21 @@ MAX_UPLOAD_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024
 SHORT_UPLOAD_PRICE = 1.0
 MEDIUM_UPLOAD_PRICE = 2.0
 LONG_UPLOAD_PRICE = 4.0
-YOUTUBE_IMPORT_DIR = Path(".generated") / "youtube-imports"
+
+
+def get_youtube_import_dir() -> Path:
+    """Get persistent YouTube import directory for Render."""
+    try:
+        temp_dir = Path(tempfile.gettempdir()) / "insightclips-youtube"
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        return temp_dir
+    except Exception:
+        fallback = Path(".") / ".generated" / "youtube-imports"
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+
+
+YOUTUBE_IMPORT_DIR = get_youtube_import_dir()
 YOUTUBE_VIDEO_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{11}$")
 YOUTUBE_HOSTS = {
     "youtube.com",
@@ -356,8 +371,10 @@ def _download_youtube_media(source: YouTubeSource, user_id: str) -> YouTubeDownl
             if not downloaded_path:
                 downloaded_path = str(info.get("filepath") or downloader.prepare_filename(info))
     except Exception as exc:
+        import logging
+        logging.exception("YouTube download failed")
         raise UploadWorkflowError(
-            "YouTube media could not be imported. Check that the video is public and try again.",
+            f"YouTube media could not be imported: {str(exc)}. Check that the video is public and try again.",
             status_code=502,
             code="youtube_import_failed",
         ) from exc

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,1 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+# Add the backend directory to sys.path so that 'app' can be imported
+backend_dir = Path(__file__).resolve().parent
+if str(backend_dir) not in sys.path:
+    sys.path.insert(0, str(backend_dir))
+
+# Add the bin directory to PATH for ffmpeg and ffprobe
+root_dir = backend_dir.parent
+bin_dir = root_dir / "bin"
+if bin_dir.exists():
+    os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+
 from app.main import app
+
+if __name__ == "__main__":
+    import uvicorn
+    # Use the PORT environment variable if available (required by Render)
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run("main:app", host="0.0.0.0", port=port, reload=True)

--- a/backend/tests/test_podcasts_analysis_router.py
+++ b/backend/tests/test_podcasts_analysis_router.py
@@ -126,6 +126,77 @@ class PodcastAnalysisRouterTests(unittest.TestCase):
         persist_analysis_result_mock.assert_not_called()
 
     @patch("app.routers.podcasts.generate_clips")
+    @patch("app.routers.podcasts.get_clips_for_podcast")
+    @patch("app.routers.podcasts.update_podcast_status_for_user")
+    @patch("app.routers.podcasts.podcast_belongs_to_user", return_value=True)
+    def test_generate_podcast_clips_allows_regenerating_partial_results(
+        self,
+        podcast_belongs_mock,
+        update_status_mock,
+        get_clips_for_podcast_mock,
+        generate_clips_mock,
+    ) -> None:
+        get_clips_for_podcast_mock.return_value = ClipGenerationResult(
+            podcast_id="podcast-123",
+            total_clips_generated=1,
+            clips=[
+                ClipResult(
+                    id="clip-1",
+                    clip_number=1,
+                    clip_start_seconds=0.0,
+                    clip_end_seconds=12.0,
+                    duration_seconds=12.0,
+                    virality_score=82.4,
+                    video_url="https://example.com/clip-1.mp4",
+                    subtitle_text="A strong subtitle line",
+                    status="ready",
+                )
+            ],
+            processing_time_seconds=0.0,
+            download_folder_url="/podcasts/podcast-123/clips",
+        )
+        generate_clips_mock.return_value = [
+            ClipResult(
+                id="clip-2",
+                clip_number=2,
+                clip_start_seconds=12.0,
+                clip_end_seconds=24.0,
+                duration_seconds=12.0,
+                virality_score=80.1,
+                video_url="https://example.com/clip-2.mp4",
+                subtitle_text="Another strong subtitle line",
+                status="ready",
+            )
+        ]
+
+        result = asyncio.run(
+            generate_podcast_clips(
+                "podcast-123",
+                GenerateClipsRequest(
+                    score_segments=[
+                        ScoreSegment(
+                            segment_start_seconds=12.0,
+                            segment_end_seconds=24.0,
+                            duration_seconds=12.0,
+                            virality_score=80.1,
+                            transcript_snippet="Another strong subtitle line",
+                            sentiment="positive",
+                            keywords=["clip"],
+                        )
+                    ],
+                    transcription=self.payload.transcription,
+                ),
+                self.user,
+            )
+        )
+
+        self.assertEqual(result.total_clips_generated, 1)
+        generate_clips_mock.assert_called_once()
+        podcast_belongs_mock.assert_called_once_with("podcast-123", "user-123")
+        update_status_mock.assert_any_call("podcast-123", "user-123", "processing")
+        update_status_mock.assert_any_call("podcast-123", "user-123", "done")
+
+    @patch("app.routers.podcasts.generate_clips")
     @patch("app.routers.podcasts.get_user_export_settings")
     @patch("app.routers.podcasts.persist_analysis_result")
     @patch("app.routers.podcasts.build_analysis_result")

--- a/build.py
+++ b/build.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import urllib.request
+import tarfile
+from pathlib import Path
+
+def main():
+    print("Installing Python requirements...")
+    subprocess.run(["pip", "install", "-r", "requirements.txt"], check=True)
+
+    print("Checking/Downloading static ffmpeg/ffprobe binaries...")
+    bin_dir = Path("bin")
+    bin_dir.mkdir(exist_ok=True)
+
+    ffmpeg_bin = bin_dir / "ffmpeg"
+    ffprobe_bin = bin_dir / "ffprobe"
+
+    if ffmpeg_bin.exists() and ffprobe_bin.exists():
+        print("ffmpeg and ffprobe already exist in bin/")
+        return
+
+    url = "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+    tar_path = Path("ffmpeg.tar.xz")
+
+    try:
+        print(f"Downloading static ffmpeg from {url}...")
+        urllib.request.urlretrieve(url, tar_path)
+        print("Extracting binaries...")
+        with tarfile.open(tar_path, "r:xz") as tar:
+            for member in tar.getmembers():
+                if member.name.endswith(("/ffmpeg", "/ffprobe")):
+                    # Extract directly to the bin directory with flat names
+                    member.name = os.path.basename(member.name)
+                    tar.extract(member, path=bin_dir)
+        
+        # Set executable permissions
+        for tool in ["ffmpeg", "ffprobe"]:
+            tool_path = bin_dir / tool
+            if tool_path.exists():
+                os.chmod(tool_path, 0o755)
+        print("ffmpeg and ffprobe installed successfully in bin/")
+    except Exception as e:
+        print(f"Warning: Failed to download/install ffmpeg: {e}")
+        print("The app will continue, but video processing features may fail.")
+    finally:
+        if tar_path.exists():
+            tar_path.unlink()
+
+if __name__ == "__main__":
+    main()

--- a/frontend/app/clips/page.tsx
+++ b/frontend/app/clips/page.tsx
@@ -413,6 +413,7 @@ function ClipsPageContent() {
     () => describeGenerationSettings(generationSettings),
     [generationSettings],
   );
+  const hasCompleteClipSet = clips.length >= generationSettings.number_of_clips;
   const topicFocusSummary = generationSettings.topic_focus.trim();
   const selectedVisualModeSummary =
     VISUAL_OUTPUT_MODES.find((mode) => mode.value === visualOutputMode) ?? VISUAL_OUTPUT_MODES[0];
@@ -806,7 +807,7 @@ function ClipsPageContent() {
       });
       return;
     }
-    if (clips.length > 0) {
+    if (hasCompleteClipSet) {
       setActionFeedback({
         tone: "info",
         message: "Clips already exist for this podcast. Use the existing clips instead of generating them again.",
@@ -1594,7 +1595,7 @@ function ClipsPageContent() {
                 <button
                   type="button"
                   onClick={() => {
-                    if (clips.length > 0) {
+                    if (hasCompleteClipSet) {
                       setWorkspaceView("results");
                       return;
                     }
@@ -1617,8 +1618,8 @@ function ClipsPageContent() {
                     boxShadow: `0 14px 30px ${t.accentGlow}`,
                   }}
                 >
-                  {generating ? <Loader2 size={16} className="animate-spin" /> : clips.length > 0 ? <PlayCircle size={16} /> : <Wand2 size={16} />}
-                  {generating ? "Rendering clips..." : clips.length > 0 ? "View generated clips" : "Generate clips"}
+                  {generating ? <Loader2 size={16} className="animate-spin" /> : hasCompleteClipSet ? <PlayCircle size={16} /> : <Wand2 size={16} />}
+                  {generating ? "Rendering clips..." : hasCompleteClipSet ? "View generated clips" : clips.length > 0 ? "Continue generation" : "Generate clips"}
                 </button>
               </div>
 
@@ -3134,7 +3135,7 @@ function ClipsPageContent() {
                     <button
                       type="button"
                       onClick={() => {
-                        if (clips.length > 0) {
+                        if (hasCompleteClipSet) {
                           setWorkspaceView("results");
                           return;
                         }
@@ -3155,8 +3156,8 @@ function ClipsPageContent() {
                         opacity: !selectedPodcastId || generating || loadingClips ? 0.72 : 1,
                       }}
                     >
-                      {generating ? <Loader2 size={16} className="animate-spin" /> : clips.length > 0 ? <PlayCircle size={16} /> : <Wand2 size={16} />}
-                      {generating ? "Rendering clips..." : clips.length > 0 ? "View generated clips" : "Generate clips"}
+                      {generating ? <Loader2 size={16} className="animate-spin" /> : hasCompleteClipSet ? <PlayCircle size={16} /> : <Wand2 size={16} />}
+                      {generating ? "Rendering clips..." : hasCompleteClipSet ? "View generated clips" : clips.length > 0 ? "Continue generation" : "Generate clips"}
                     </button>
                     <button
                       type="button"

--- a/frontend/app/upload/UploadWorkspace.tsx
+++ b/frontend/app/upload/UploadWorkspace.tsx
@@ -37,6 +37,7 @@ import {
   type UploadPriceResponse,
   type UploadState,
   type YouTubeImportResponse,
+  shouldUseMockUploadFlow,
 } from "@/lib/api";
 import { getAudioEnhancementFeedback } from "@/lib/audio-enhancement";
 import {
@@ -54,7 +55,6 @@ import { getStudioTheme, THEME_STORAGE_KEY } from "@/lib/brand";
 
 const ACCEPTED_TYPES = ["video/mp4", "video/quicktime", "video/webm", "video/x-m4v"];
 const ACCEPTED_EXT = [".mp4", ".mov", ".webm", ".m4v"];
-const PREFLIGHT_MODE = process.env.NEXT_PUBLIC_UPLOAD_PREFLIGHT_MODE ?? "real";
 const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 const YOUTUBE_HOSTS = new Set([
   "youtube.com",
@@ -439,30 +439,86 @@ export default function UploadWorkspace({
     token: string | null,
     mock: boolean,
   ) => {
-    const duration = await getDuration(selectedFile);
-    const formData = new FormData();
-    formData.set("file", selectedFile);
-    formData.set("filename", selectedFile.name);
-    if (selectedFile.type) formData.set("mime_type", selectedFile.type);
-    formData.set("detected_duration_seconds", String(duration));
-    if (mock) formData.set("mock", "true");
+    if (mock) {
+      const duration = await getDuration(selectedFile);
+      const formData = new FormData();
+      formData.set("file", selectedFile);
+      formData.set("filename", selectedFile.name);
+      if (selectedFile.type) formData.set("mime_type", selectedFile.type);
+      formData.set("detected_duration_seconds", String(duration));
+      formData.set("mock", "true");
 
-    const response = await fetch("/api/upload/preflight", {
+      const response = await fetch("/api/upload/preflight", {
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: formData,
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(typeof payload.detail === "string" ? payload.detail : "Unable to inspect file.");
+      }
+
+      const typed = payload as UploadPriceResponse & { upload_reference?: string };
+      if (!typed.upload_reference) {
+        throw new Error("Upload staging failed. No upload reference was returned.");
+      }
+      setUploadReference(typed.upload_reference);
+      return typed as UploadPriceResponse;
+    }
+
+    // REAL MODE: Upload directly to Render backend
+    const backendUrl =
+      process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/$/, "") ?? "http://localhost:8000";
+
+    const uploadFormData = new FormData();
+    uploadFormData.append("file", selectedFile);
+
+    const uploadResponse = await fetch(`${backendUrl}/upload/file`, {
       method: "POST",
       headers: token ? { Authorization: `Bearer ${token}` } : {},
-      body: formData,
+      body: uploadFormData,
     });
-    const payload = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(typeof payload.detail === "string" ? payload.detail : "Unable to inspect file.");
+
+    if (!uploadResponse.ok) {
+      const errorPayload = await uploadResponse.json().catch(() => ({}));
+      throw new Error(
+        typeof errorPayload.detail === "string"
+          ? errorPayload.detail
+          : "Failed to upload file to backend."
+      );
     }
 
-    const typed = payload as UploadPriceResponse & { upload_reference?: string };
-    if (!typed.upload_reference) {
-      throw new Error("Upload staging failed. No upload reference was returned.");
+    const uploadData = (await uploadResponse.json()) as {
+      storage_path: string;
+      filesize_bytes: number;
+    };
+
+    const priceResponse = await fetch(`${backendUrl}/upload/calculate-price`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        filename: selectedFile.name,
+        filesize_bytes: uploadData.filesize_bytes,
+        mime_type: selectedFile.type || undefined,
+        storage_path: uploadData.storage_path,
+      }),
+    });
+
+    if (!priceResponse.ok) {
+      const errorPayload = await priceResponse.json().catch(() => ({}));
+      throw new Error(
+        typeof errorPayload.detail === "string"
+          ? errorPayload.detail
+          : "Failed to calculate upload price."
+      );
     }
-    setUploadReference(typed.upload_reference);
-    return typed as UploadPriceResponse;
+
+    const priceData = (await priceResponse.json()) as UploadPriceResponse;
+    setUploadReference(uploadData.storage_path);
+    return priceData;
   };
 
   const runServerPrepare = async (
@@ -475,7 +531,38 @@ export default function UploadWorkspace({
       throw new Error("Upload staging is missing. Please run the pre-flight check again.");
     }
 
-    const response = await fetch("/api/upload/prepare", {
+    if (mock) {
+      const response = await fetch("/api/upload/prepare", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          title: titleFrom(selectedFile.name),
+          filename: selectedFile.name,
+          filesize_bytes: selectedFile.size,
+          mime_type: selectedFile.type || undefined,
+          duration_seconds: quote.duration_seconds,
+          price: quote.price,
+          status: quote.status,
+          upload_reference: uploadReference,
+          mock,
+          export_settings: exportSettings,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(typeof payload.detail === "string" ? payload.detail : "Unable to create record.");
+      }
+      return payload as PrepareUploadResponse;
+    }
+
+    // REAL MODE: Call prepare directly on backend
+    const backendUrl =
+      process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/$/, "") ?? "http://localhost:8000";
+
+    const response = await fetch(`${backendUrl}/upload/prepare`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -489,11 +576,11 @@ export default function UploadWorkspace({
         duration_seconds: quote.duration_seconds,
         price: quote.price,
         status: quote.status,
-        upload_reference: uploadReference,
-        mock,
+        storage_path: uploadReference,
         export_settings: exportSettings,
       }),
     });
+
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) {
       throw new Error(typeof payload.detail === "string" ? payload.detail : "Unable to create record.");
@@ -523,7 +610,7 @@ export default function UploadWorkspace({
     setUploadReference(null);
 
     try {
-      const mock = PREFLIGHT_MODE === "mock";
+      const mock = shouldUseMockUploadFlow();
       const token = backendToken ?? (await syncBackendSession());
       if (!token && !mock) {
         router.replace("/login");
@@ -588,7 +675,7 @@ export default function UploadWorkspace({
     setPreparing(true);
     setErr("");
     try {
-      const mock = PREFLIGHT_MODE === "mock";
+      const mock = shouldUseMockUploadFlow();
       const token = backendToken ?? (await syncBackendSession());
       if (!token && !mock) {
         router.replace("/login");
@@ -615,7 +702,7 @@ export default function UploadWorkspace({
     setErr("");
 
     try {
-      const mock = PREFLIGHT_MODE === "mock";
+      const mock = shouldUseMockUploadFlow();
       const token = backendToken ?? (await syncBackendSession());
       if (!token && !mock) {
         router.replace("/login");
@@ -650,7 +737,7 @@ export default function UploadWorkspace({
     setYoutubeAnalyzing(true);
     setErr("");
     try {
-      const mock = PREFLIGHT_MODE === "mock";
+      const mock = shouldUseMockUploadFlow();
       const token = backendToken ?? (await syncBackendSession());
       if (!token && !mock) {
         router.replace("/login");

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -49,9 +49,24 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter()
 
   const syncBackendSession = async (): Promise<string | null> => {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession()
+    let session = null
+
+    try {
+      const result = await supabase.auth.getSession()
+      session = result.data.session
+    } catch (error) {
+      clearBackendToken()
+      setBackendToken(null)
+      if (String(error).toLowerCase().includes('invalid refresh token')) {
+        try {
+          await supabase.auth.signOut()
+        } catch {
+          // Ignore sign-out cleanup failures and continue with a clean local state.
+        }
+        return null
+      }
+      throw error
+    }
 
     if (!session?.access_token) {
       clearBackendToken()
@@ -96,9 +111,20 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     let active = true
 
     const bootstrap = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
+      let session = null
+
+      try {
+        const result = await supabase.auth.getSession()
+        session = result.data.session
+      } catch (error) {
+        clearBackendToken()
+        setBackendToken(null)
+        if (active) {
+          setUser(null)
+          setLoading(false)
+        }
+        return
+      }
 
       if (!active) {
         return

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -21,10 +21,18 @@ const BACKEND_IS_LOCAL = (() => {
     return true;
   }
 })();
+const CLIENT_IS_LOCALHOST = (() => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const hostname = window.location.hostname.toLowerCase();
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+})();
 
 export const BACKEND_TOKEN_KEY = "insightclips_backend_token";
 export const FRONTEND_UPLOAD_PREFLIGHT_MODE =
-  uploadPreflightMode === "mock" && BACKEND_IS_LOCAL ? "mock" : "live";
+  uploadPreflightMode === "mock" && BACKEND_IS_LOCAL && CLIENT_IS_LOCALHOST ? "mock" : "live";
 
 export function shouldUseMockUploadFlow(): boolean {
   return FRONTEND_UPLOAD_PREFLIGHT_MODE === "mock";

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,11 +12,23 @@ import {
 
 const configuredBackendUrl =
   process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/$/, "") ?? "http://localhost:8000";
-const uploadPreflightMode = process.env.NEXT_PUBLIC_UPLOAD_PREFLIGHT_MODE ?? "real";
+const uploadPreflightMode = process.env.NEXT_PUBLIC_UPLOAD_PREFLIGHT_MODE?.trim().toLowerCase() ?? "real";
+const BACKEND_IS_LOCAL = (() => {
+  try {
+    const host = new URL(configuredBackendUrl).hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return true;
+  }
+})();
 
 export const BACKEND_TOKEN_KEY = "insightclips_backend_token";
 export const FRONTEND_UPLOAD_PREFLIGHT_MODE =
-  process.env.NEXT_PUBLIC_UPLOAD_PREFLIGHT_MODE?.trim().toLowerCase() ?? "live";
+  uploadPreflightMode === "mock" && BACKEND_IS_LOCAL ? "mock" : "live";
+
+export function shouldUseMockUploadFlow(): boolean {
+  return FRONTEND_UPLOAD_PREFLIGHT_MODE === "mock";
+}
 
 type JsonRecord = Record<string, unknown>;
 
@@ -798,7 +810,7 @@ export async function calculateUploadPrice(
   payload: UploadPriceRequest,
   options: UploadRequestOptions = {},
 ): Promise<UploadPriceResponse> {
-  if (options.useMock ?? uploadPreflightMode === "mock") {
+  if (options.useMock ?? shouldUseMockUploadFlow()) {
     return buildMockUploadPrice(payload);
   }
 
@@ -809,7 +821,7 @@ export async function prepareUpload(
   payload: PrepareUploadRequest,
   options: UploadRequestOptions = {},
 ): Promise<PrepareUploadResponse> {
-  if (options.useMock ?? uploadPreflightMode === "mock") {
+  if (options.useMock ?? shouldUseMockUploadFlow()) {
     return buildMockPrepareResponse(payload);
   }
 
@@ -820,7 +832,7 @@ export async function importYouTubePodcast(
   payload: YouTubeImportPayload,
   options: UploadRequestOptions = {},
 ): Promise<YouTubeImportResponse> {
-  if (options.useMock ?? uploadPreflightMode === "mock") {
+  if (options.useMock ?? shouldUseMockUploadFlow()) {
     return buildMockYouTubeImportResponse(payload);
   }
 


### PR DESCRIPTION
Description
This PR fixes the main upload and clip-generation issues without touching main directly.

What changed:

Prevented Vercel from using the mock upload flow in production.
Kept upload/preflight requests on the real backend (Render) only.
Fixed stale Supabase auth refresh handling so local testing does not break on Invalid Refresh Token.
Allowed clip generation to continue when only part of the requested clip set already exists.
Updated the clips UI so it shows Continue generation until the full target set is generated.
Added backend coverage for partial regeneration behavior.
Testing:

Frontend test suite passes.
Backend router file compiles successfully.