### PR TITLE
fix: improve Penar Kera frontend review flow

### DIFF
--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -529,7 +529,7 @@ function AnalyticsPageContent() {
                 </div>
                 {selectedPodcast ? (
                   <Link
-                    href={`/clips?podcastId=${selectedPodcast.id}`}
+                    href={`/clips/generated?podcastId=${selectedPodcast.id}`}
                     style={{
                       borderRadius: 999,
                       padding: "11px 16px",

--- a/frontend/app/clips/generate/page.tsx
+++ b/frontend/app/clips/generate/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Suspense } from "react";
+
+import { ClipsPageContent } from "../page";
+
+export default function GenerateClipsPage() {
+  return (
+    <Suspense fallback={null}>
+      <ClipsPageContent mode="generate" />
+    </Suspense>
+  );
+}

--- a/frontend/app/clips/generated/page.tsx
+++ b/frontend/app/clips/generated/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Suspense } from "react";
+
+import { ClipsPageContent } from "../page";
+
+export default function GeneratedClipsPage() {
+  return (
+    <Suspense fallback={null}>
+      <ClipsPageContent mode="results" />
+    </Suspense>
+  );
+}

--- a/frontend/app/clips/page.tsx
+++ b/frontend/app/clips/page.tsx
@@ -186,6 +186,18 @@ function collectPlanningHashtags(suggestions: ContentCalendarSuggestion[]): stri
   return hashtags.slice(0, 8);
 }
 
+function buildPlanningPostCopy(suggestion: ContentCalendarSuggestion): string {
+  return [
+    suggestion.title,
+    suggestion.caption,
+    suggestion.hashtags.join(" "),
+    suggestion.call_to_action,
+  ]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join("\n\n");
+}
+
 function toDiscoveryClips(clips: ClipResult[], podcast: Podcast | null): ClipSearchResult[] {
   if (!podcast) {
     return [];
@@ -327,10 +339,17 @@ function formatGenerationFailureMessage(error: unknown): string {
   return baseMessage;
 }
 
-function ClipsPageContent() {
+type ClipsPageMode = "results" | "generate";
+
+type ClipsPageContentProps = {
+  mode?: ClipsPageMode;
+};
+
+export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { backendToken, loading: authLoading, syncBackendSession } = useAuth();
+  const lockedWorkspaceView: "setup" | "results" = mode === "generate" ? "setup" : "results";
 
   const [mounted, setMounted] = useState(false);
   const [dark, setDark] = useState(true);
@@ -359,7 +378,7 @@ function ClipsPageContent() {
     tone: "success" | "error" | "info";
     message: string;
   } | null>(null);
-  const [workspaceView, setWorkspaceView] = useState<"setup" | "results">("setup");
+  const [workspaceView, setWorkspaceView] = useState<"setup" | "results">(lockedWorkspaceView);
   const [showAdvancedControls, setShowAdvancedControls] = useState(false);
   const [generationTemplateId, setGenerationTemplateId] =
     useState<GenerationTemplateId>("hook_spotlight");
@@ -375,6 +394,10 @@ function ClipsPageContent() {
   const isMobile = viewportWidth < 960;
   const selectedPodcast =
     podcasts.find((podcast) => podcast.id === selectedPodcastId) ?? null;
+  const generationPath = selectedPodcastId ? `/clips?podcastId=${selectedPodcastId}` : "/clips";
+  const resultsPath = selectedPodcastId
+    ? `/clips/generated?podcastId=${selectedPodcastId}`
+    : "/clips/generated";
   const activeSearch = searchQuery.trim().length > 0 || filter !== "all";
   const overlayByClipId = useMemo(
     () => new Map(clips.map((clip) => [clip.id, clip.overlay ?? null])),
@@ -704,15 +727,15 @@ function ClipsPageContent() {
   }, [selectedPodcast]);
 
   useEffect(() => {
-    setWorkspaceView("setup");
+    setWorkspaceView(lockedWorkspaceView);
     setShowAdvancedControls(false);
-  }, [selectedPodcastId]);
+  }, [lockedWorkspaceView, selectedPodcastId]);
 
   useEffect(() => {
-    if (clips.length > 0) {
+    if (mode === "results" && clips.length > 0) {
       setWorkspaceView("results");
     }
-  }, [clips]);
+  }, [clips, mode]);
 
   const syncClipEverywhere = (
     clipId: string,
@@ -857,6 +880,9 @@ function ClipsPageContent() {
         setContentCalendar(calendar);
       }
       setWorkspaceView("results");
+      if (mode === "generate") {
+        router.push(resultsPath);
+      }
       setActionFeedback({
         tone: "success",
         message: `Generated ${generated.clips.length} clip${generated.clips.length === 1 ? "" : "s"} for ${selectedPodcast?.title ?? "this podcast"} using ${generationSettings.clip_duration_seconds}s targets.`,
@@ -870,6 +896,9 @@ function ClipsPageContent() {
             selectedPodcast ? toDiscoveryClips(partialResult.clips, selectedPodcast) : [],
           );
           setWorkspaceView("results");
+          if (mode === "generate") {
+            router.push(resultsPath);
+          }
           setActionFeedback({
             tone: "info",
             message: `Showing ${partialResult.clips.length} clip${partialResult.clips.length === 1 ? "" : "s"} that finished rendering. The rest may still need another generation run.`,
@@ -899,16 +928,32 @@ function ClipsPageContent() {
     }
 
     try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error("Clipboard API is not available.");
+      }
       await navigator.clipboard.writeText(value);
       setActionFeedback({
         tone: "success",
         message: `${label} copied to your clipboard.`,
       });
     } catch (copyError) {
+      const textarea = document.createElement("textarea");
+      textarea.value = value;
+      textarea.setAttribute("readonly", "true");
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      textarea.style.top = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+
+      const copied = document.execCommand("copy");
+      document.body.removeChild(textarea);
+
       setActionFeedback({
-        tone: "error",
-        message:
-          copyError instanceof Error
+        tone: copied ? "success" : "error",
+        message: copied
+          ? `${label} copied to your clipboard.`
+          : copyError instanceof Error
             ? copyError.message
             : `Unable to copy ${label.toLowerCase()}.`,
       });
@@ -1281,7 +1326,7 @@ function ClipsPageContent() {
             <div
               className="lift-card"
               style={{
-                borderRadius: 24,
+                borderRadius: 20,
                 border: `1px solid ${t.borderSub}`,
                 background: t.cardAlt,
                 padding: "20px 22px",
@@ -1365,7 +1410,7 @@ function ClipsPageContent() {
           style={{
             display: "grid",
             gridTemplateColumns: isMobile ? "1fr" : "320px minmax(0, 1fr)",
-            gap: 20,
+            gap: 18,
             marginTop: 22,
             alignItems: "start",
           }}
@@ -1432,105 +1477,90 @@ function ClipsPageContent() {
               )}
             </section>
 
-            <section
-              className="lift-card ic-premium-card"
-              style={{
-                borderRadius: 24,
-                background: t.card,
-                border: `1px solid ${t.border}`,
-                padding: 18,
-              }}
-            >
-              <div style={{ fontSize: 11, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 12 }}>
-                Recommendations
-              </div>
-              {loadingRecommendations ? (
-                <div style={{ display: "flex", alignItems: "center", gap: 10, color: t.textSub }}>
-                  <Loader2 size={18} className="animate-spin" />
-                  Loading recommendations...
+            {mode === "results" ? (
+              <section
+                className="lift-card ic-premium-card"
+                style={{
+                  borderRadius: 24,
+                  background: t.card,
+                  border: `1px solid ${t.border}`,
+                  padding: 18,
+                }}
+              >
+                <div style={{ fontSize: 11, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 12 }}>
+                  Recommendations
                 </div>
-              ) : recommendations.length === 0 ? (
-                <div style={{ display: "grid", gap: 12 }}>
-                  <div style={{ color: t.textSub, lineHeight: 1.75 }}>
-                    Recommendations will appear here after clips are generated for the selected podcast.
+                {loadingRecommendations ? (
+                  <div style={{ display: "flex", alignItems: "center", gap: 10, color: t.textSub }}>
+                    <Loader2 size={18} className="animate-spin" />
+                    Loading recommendations...
                   </div>
-                  {selectedPodcast ? (
-                    <Link
-                      href={`/analytics?podcastId=${selectedPodcast.id}`}
-                      style={{
-                        width: "fit-content",
-                        borderRadius: 999,
-                        padding: "10px 14px",
-                        background: t.cardAlt,
-                        border: `1px solid ${t.borderSub}`,
-                        color: t.textSub,
-                        textDecoration: "none",
-                        fontWeight: 700,
-                      }}
-                    >
-                      Open analytics context
-                    </Link>
-                  ) : null}
-                </div>
-              ) : (
-                <div style={{ display: "grid", gap: 10 }}>
-                  {recommendationsEstimated ? (
-                    <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.65 }}>
-                      Showing estimated recommendations based on current clip scores while the dedicated endpoint is unavailable.
+                ) : recommendations.length === 0 ? (
+                  <div style={{ display: "grid", gap: 12 }}>
+                    <div style={{ color: t.textSub, lineHeight: 1.75 }}>
+                      Recommendations will appear here after clips are generated for the selected podcast.
                     </div>
-                  ) : null}
-                  {visibleRecommendations.map((clip) => {
-                    const overlayState = getOverlayState(clip.overlay);
-
-                    return (
-                      <article
-                        key={clip.id}
-                        className="ic-premium-card"
+                    {selectedPodcast ? (
+                      <Link
+                        href={`/analytics?podcastId=${selectedPodcast.id}`}
                         style={{
-                          borderRadius: 18,
-                          border: `1px solid ${t.borderSub}`,
+                          width: "fit-content",
+                          borderRadius: 999,
+                          padding: "10px 14px",
                           background: t.cardAlt,
-                          padding: 14,
+                          border: `1px solid ${t.borderSub}`,
+                          color: t.textSub,
+                          textDecoration: "none",
+                          fontWeight: 700,
                         }}
                       >
-                        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, marginBottom: 8 }}>
-                          <div>
-                            <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint }}>
-                              Clip {clip.clip_number}
+                        Open analytics context
+                      </Link>
+                    ) : null}
+                  </div>
+                ) : (
+                  <div style={{ display: "grid", gap: 10 }}>
+                    {recommendationsEstimated ? (
+                      <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.65 }}>
+                        Showing estimated recommendations based on current clip scores while the dedicated endpoint is unavailable.
+                      </div>
+                    ) : null}
+                    {visibleRecommendations.map((clip) => {
+                      const overlayState = getOverlayState(clip.overlay);
+
+                      return (
+                        <article
+                          key={clip.id}
+                          className="ic-premium-card"
+                          style={{
+                            borderRadius: 18,
+                            border: `1px solid ${t.borderSub}`,
+                            background: t.cardAlt,
+                            padding: 14,
+                          }}
+                        >
+                          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, marginBottom: 8 }}>
+                            <div>
+                              <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint }}>
+                                Clip {clip.clip_number}
+                              </div>
+                              <div style={{ marginTop: 4, fontWeight: 700 }}>{clip.recommendation_reason ?? "Recommended next"}</div>
                             </div>
-                            <div style={{ marginTop: 4, fontWeight: 700 }}>{clip.recommendation_reason ?? "Recommended next"}</div>
+                            <div style={{ borderRadius: 999, background: t.chip, color: t.accent, fontWeight: 700, padding: "7px 10px", height: "fit-content" }}>
+                              {clip.virality_score.toFixed(1)}
+                            </div>
                           </div>
-                          <div style={{ borderRadius: 999, background: t.chip, color: t.accent, fontWeight: 700, padding: "7px 10px", height: "fit-content" }}>
-                            {clip.virality_score.toFixed(1)}
+                          <div style={{ color: t.textSub, fontSize: 13, lineHeight: 1.7 }}>
+                            {clip.subtitle_text}
                           </div>
-                        </div>
-                        <div style={{ color: t.textSub, fontSize: 13, lineHeight: 1.7 }}>
-                          {clip.subtitle_text}
-                        </div>
-                        {overlayState.variant === "enabled" ? (
-                          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 10 }}>
-                            <span
-                              style={{
-                                borderRadius: 999,
-                                background: t.chip,
-                                border: `1px solid ${t.accent}`,
-                                color: t.accent,
-                                fontSize: 11,
-                                fontWeight: 700,
-                                letterSpacing: ".08em",
-                                textTransform: "uppercase",
-                                padding: "6px 10px",
-                              }}
-                            >
-                              {overlayState.badge}
-                            </span>
-                            {overlayState.category ? (
+                          {overlayState.variant === "enabled" ? (
+                            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 10 }}>
                               <span
                                 style={{
                                   borderRadius: 999,
-                                  background: "transparent",
-                                  border: `1px solid ${t.borderSub}`,
-                                  color: t.textSub,
+                                  background: t.chip,
+                                  border: `1px solid ${t.accent}`,
+                                  color: t.accent,
                                   fontSize: 11,
                                   fontWeight: 700,
                                   letterSpacing: ".08em",
@@ -1538,17 +1568,34 @@ function ClipsPageContent() {
                                   padding: "6px 10px",
                                 }}
                               >
-                                {overlayState.category}
+                                {overlayState.badge}
                               </span>
-                            ) : null}
-                          </div>
-                        ) : null}
-                      </article>
-                    );
-                  })}
-                </div>
-              )}
-            </section>
+                              {overlayState.category ? (
+                                <span
+                                  style={{
+                                    borderRadius: 999,
+                                    background: "transparent",
+                                    border: `1px solid ${t.borderSub}`,
+                                    color: t.textSub,
+                                    fontSize: 11,
+                                    fontWeight: 700,
+                                    letterSpacing: ".08em",
+                                    textTransform: "uppercase",
+                                    padding: "6px 10px",
+                                  }}
+                                >
+                                  {overlayState.category}
+                                </span>
+                              ) : null}
+                            </div>
+                          ) : null}
+                        </article>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+            ) : null}
           </aside>
 
           <main
@@ -1561,10 +1608,10 @@ function ClipsPageContent() {
             <section
               className="ic-premium-card"
               style={{
-                borderRadius: 24,
+                borderRadius: 20,
                 background: t.card,
                 border: `1px solid ${t.border}`,
-                padding: 20,
+                padding: 18,
               }}
             >
               <div
@@ -1581,7 +1628,7 @@ function ClipsPageContent() {
                   <div style={{ fontSize: 11, letterSpacing: ".18em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
                     Clip workspace
                   </div>
-                  <h2 style={{ fontFamily: "'DM Serif Display', serif", fontSize: 34, lineHeight: 1.08, margin: 0 }}>
+                  <h2 style={{ fontFamily: "'DM Serif Display', serif", fontSize: isMobile ? 28 : 32, lineHeight: 1.08, margin: 0 }}>
                     {selectedPodcast?.title ?? "Choose a podcast"}
                   </h2>
                   <p style={{ marginTop: 8, color: t.textSub }}>
@@ -1594,8 +1641,12 @@ function ClipsPageContent() {
                 <button
                   type="button"
                   onClick={() => {
+                    if (mode === "results") {
+                      router.push(generationPath);
+                      return;
+                    }
                     if (clips.length > 0) {
-                      setWorkspaceView("results");
+                      router.push(resultsPath);
                       return;
                     }
                     void handleGenerateClips();
@@ -1618,56 +1669,14 @@ function ClipsPageContent() {
                   }}
                 >
                   {generating ? <Loader2 size={16} className="animate-spin" /> : clips.length > 0 ? <PlayCircle size={16} /> : <Wand2 size={16} />}
-                  {generating ? "Rendering clips..." : clips.length > 0 ? "View generated clips" : "Generate clips"}
+                  {generating
+                    ? "Rendering clips..."
+                    : mode === "results"
+                      ? "Open generation setup"
+                      : clips.length > 0
+                        ? "View generated clips"
+                        : "Generate clips"}
                 </button>
-              </div>
-
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: viewportWidth < 900 ? "1fr" : "repeat(3,minmax(0,1fr))",
-                  gap: 10,
-                  marginBottom: 18,
-                }}
-              >
-                {[
-                  {
-                    label: "Generation controls",
-                    detail: "Set clip length, topic focus, and subtitle behavior before you render.",
-                  },
-                  {
-                    label: "Creative polish",
-                    detail: "Adjust the visual output mode and carry a cleaner subtitle style into the final clips.",
-                  },
-                  {
-                    label: "Publish handoff",
-                    detail: "Move from generation to recommendations, planning, export, and publishing in one place.",
-                  },
-                ].map((item) => (
-                  <div
-                    key={item.label}
-                    style={{
-                      borderRadius: 18,
-                      border: `1px solid ${t.borderSub}`,
-                      background: t.cardAlt,
-                      padding: "14px 15px",
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontSize: 10,
-                        letterSpacing: ".18em",
-                        textTransform: "uppercase",
-                        color: t.accentLt,
-                        fontWeight: 700,
-                        marginBottom: 6,
-                      }}
-                    >
-                      {item.label}
-                    </div>
-                    <div style={{ fontSize: 12, lineHeight: 1.65, color: t.textSub }}>{item.detail}</div>
-                  </div>
-                ))}
               </div>
 
               <section
@@ -1689,20 +1698,20 @@ function ClipsPageContent() {
                     Workspace view
                   </div>
                   <div style={{ fontSize: 13, color: t.textSub, lineHeight: 1.65 }}>
-                    Keep setup light first, then switch to results when you want previews, planning, and publishing.
+                    Setup keeps generation controls separate. Results keeps previews, search, planning, and publish actions separate.
                   </div>
                 </div>
                 <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                   {([
-                    { id: "setup", label: "Quick setup" },
-                    { id: "results", label: "Results" },
+                    { id: "setup", label: "Generation", href: generationPath },
+                    { id: "results", label: "Results", href: resultsPath },
                   ] as const).map((item) => {
                     const active = workspaceView === item.id;
                     return (
                       <button
                         key={item.id}
                         type="button"
-                        onClick={() => setWorkspaceView(item.id)}
+                        onClick={() => router.push(item.href)}
                         style={{
                           border: "none",
                           borderRadius: 999,
@@ -1722,68 +1731,70 @@ function ClipsPageContent() {
                 </div>
               </section>
 
-              <GenerationSettingsPanel
-                dark={dark}
-                templateId={generationTemplateId}
-                settings={generationSettings}
-                onTemplateChange={handleGenerationTemplateChange}
-                onSettingsChange={handleGenerationSettingsChange}
-                storageHint="These preferences are reused across the upload and clips workflow on this device."
-                palette={{
-                  border: t.border,
-                  subBorder: t.borderSub,
-                  muted: t.textSub,
-                  hi: t.accent,
-                  hi2: t.accentLt,
-                }}
-              />
+              {workspaceView === "setup" ? (
+                <>
+                  <GenerationSettingsPanel
+                    dark={dark}
+                    templateId={generationTemplateId}
+                    settings={generationSettings}
+                    onTemplateChange={handleGenerationTemplateChange}
+                    onSettingsChange={handleGenerationSettingsChange}
+                    storageHint="These preferences are reused across the upload and clips workflow on this device."
+                    palette={{
+                      border: t.border,
+                      subBorder: t.borderSub,
+                      muted: t.textSub,
+                      hi: t.accent,
+                      hi2: t.accentLt,
+                    }}
+                  />
 
-              <section
-                style={{
-                  borderRadius: 20,
-                  border: `1px solid ${t.borderSub}`,
-                  background: t.cardAlt,
-                  padding: "14px 15px",
-                  marginBottom: 16,
-                }}
-              >
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    gap: 12,
-                    alignItems: "center",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <div>
-                    <div style={{ fontSize: 10, letterSpacing: ".18em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
-                      Advanced controls
-                    </div>
-                    <div style={{ fontSize: 13, color: t.textSub, lineHeight: 1.65 }}>
-                      Open visual mode and subtitle styling only when you need deeper polishing.
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => setShowAdvancedControls((current) => !current)}
+                  <section
                     style={{
+                      borderRadius: 20,
                       border: `1px solid ${t.borderSub}`,
-                      borderRadius: 999,
-                      padding: "10px 14px",
-                      background: showAdvancedControls ? t.chip : t.card,
-                      color: showAdvancedControls ? t.accent : t.textSub,
-                      fontWeight: 700,
-                      cursor: "pointer",
+                      background: t.cardAlt,
+                      padding: "14px 15px",
+                      marginBottom: 16,
                     }}
                   >
-                    {showAdvancedControls ? "Hide advanced" : "Open advanced"}
-                  </button>
-                </div>
-              </section>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: 12,
+                        alignItems: "center",
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <div>
+                        <div style={{ fontSize: 10, letterSpacing: ".18em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
+                          Advanced controls
+                        </div>
+                        <div style={{ fontSize: 13, color: t.textSub, lineHeight: 1.65 }}>
+                          Open visual mode and subtitle styling only when you need deeper polishing.
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setShowAdvancedControls((current) => !current)}
+                        style={{
+                          border: `1px solid ${t.borderSub}`,
+                          borderRadius: 999,
+                          padding: "10px 14px",
+                          background: showAdvancedControls ? t.chip : t.card,
+                          color: showAdvancedControls ? t.accent : t.textSub,
+                          fontWeight: 700,
+                          cursor: "pointer",
+                        }}
+                      >
+                        {showAdvancedControls ? "Hide advanced" : "Open advanced"}
+                      </button>
+                    </div>
+                  </section>
 
-              {showAdvancedControls ? (
-                <div style={{ display: "grid", gap: 16 }}>
+                  {showAdvancedControls ? (
+                    <div style={{ display: "grid", gap: 16 }}>
               <section
                 className="glass a2"
                 style={{
@@ -1954,7 +1965,9 @@ function ClipsPageContent() {
                   hi2: t.accentLt,
                 }}
               />
-                </div>
+                    </div>
+                  ) : null}
+                </>
               ) : null}
 
               {workspaceView === "results" ? (
@@ -2035,6 +2048,7 @@ function ClipsPageContent() {
                     display: "grid",
                     gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
                     gap: 10,
+                    alignItems: "stretch",
                     marginBottom: 16,
                   }}
                 >
@@ -2071,10 +2085,13 @@ function ClipsPageContent() {
                     <div
                       key={item.label}
                       style={{
+                        display: "flex",
+                        flexDirection: "column",
                         borderRadius: 16,
                         border: `1px solid ${t.borderSub}`,
                         background: t.cardAlt,
                         padding: "14px 15px",
+                        minHeight: 168,
                       }}
                     >
                       <div
@@ -2099,7 +2116,7 @@ function ClipsPageContent() {
                       >
                         {item.value}
                       </div>
-                      <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.6 }}>
+                      <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.6, marginTop: "auto" }}>
                         {item.detail}
                       </div>
                     </div>
@@ -2129,111 +2146,172 @@ function ClipsPageContent() {
                       display: "grid",
                       gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 220px), 1fr))",
                       gap: 12,
+                      alignItems: "stretch",
                     }}
                   >
                     {calendarPreview.map((suggestion) => (
-                      <article
+                      <details
                         key={`${suggestion.clip_id}-${suggestion.platform}`}
                         style={{
                           borderRadius: 18,
                           border: `1px solid ${t.borderSub}`,
                           background: t.cardAlt,
-                          padding: 14,
+                          padding: 0,
+                          minHeight: 168,
+                          overflow: "hidden",
                         }}
                       >
-                        <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginBottom: 10 }}>
-                          <div>
-                            <div style={{ fontSize: 10, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint }}>
-                              Clip {suggestion.clip_number}
+                        <summary
+                          style={{
+                            listStyle: "none",
+                            cursor: "pointer",
+                            padding: 14,
+                          }}
+                        >
+                          <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginBottom: 10 }}>
+                            <div>
+                              <div style={{ fontSize: 10, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint }}>
+                                Clip {suggestion.clip_number}
+                              </div>
+                              <div style={{ marginTop: 4, fontWeight: 800, color: t.text }}>
+                                {formatPlatformLabel(suggestion.platform)}
+                              </div>
                             </div>
-                            <div style={{ marginTop: 4, fontWeight: 700 }}>{formatPlatformLabel(suggestion.platform)}</div>
-                          </div>
-                          <div
-                            style={{
-                              borderRadius: 999,
-                              border: `1px solid ${t.borderSub}`,
-                              background: t.chip,
-                              color: t.accent,
-                              padding: "6px 10px",
-                              fontSize: 11,
-                              fontWeight: 700,
-                            }}
-                          >
-                            Day {suggestion.scheduled_day}
-                          </div>
-                        </div>
-                        <div style={{ fontSize: 13, fontWeight: 700, color: t.text, lineHeight: 1.55, marginBottom: 6 }}>
-                          {suggestion.title}
-                        </div>
-                        <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.65, marginBottom: 8 }}>
-                          Best time: {suggestion.best_time_local}
-                        </div>
-                        <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.65, marginBottom: 10 }}>
-                          {truncateText(suggestion.caption, 140)}
-                        </div>
-                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 10 }}>
-                          {suggestion.hashtags.slice(0, 4).map((hashtag) => (
-                            <span
-                              key={hashtag}
+                            <div
                               style={{
                                 borderRadius: 999,
                                 border: `1px solid ${t.borderSub}`,
-                                background: "transparent",
-                                color: t.textSub,
+                                background: t.chip,
+                                color: t.accent,
+                                padding: "6px 10px",
                                 fontSize: 11,
-                                fontWeight: 700,
-                                padding: "5px 9px",
+                                fontWeight: 800,
+                                height: "fit-content",
                               }}
                             >
-                              {hashtag}
-                            </span>
-                          ))}
-                        </div>
-                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                          <button
-                            type="button"
-                            onClick={() => void handleCopyPlanning(suggestion.caption, "Caption")}
+                              Day {suggestion.scheduled_day}
+                            </div>
+                          </div>
+                          <div style={{ fontSize: 13, fontWeight: 800, color: t.text, lineHeight: 1.45, marginBottom: 6 }}>
+                            {truncateText(suggestion.title, 64)}
+                          </div>
+                          <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.55 }}>
+                            Best time: {suggestion.best_time_local}
+                          </div>
+                          <div
                             style={{
-                              border: `1px solid ${t.borderSub}`,
+                              marginTop: 10,
+                              width: "fit-content",
                               borderRadius: 999,
+                              border: `1px solid ${t.borderSub}`,
                               background: "transparent",
                               color: t.textSub,
-                              padding: "8px 12px",
-                              display: "inline-flex",
-                              alignItems: "center",
-                              gap: 6,
-                              fontWeight: 700,
-                              cursor: "pointer",
+                              padding: "6px 9px",
+                              fontSize: 11,
+                              fontWeight: 800,
                             }}
                           >
-                            <Copy size={13} />
-                            Copy caption
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => void handleCopyPlanning(suggestion.hashtags.join(" "), "Hashtags")}
-                            style={{
-                              border: `1px solid ${t.borderSub}`,
-                              borderRadius: 999,
-                              background: "transparent",
-                              color: t.textSub,
-                              padding: "8px 12px",
-                              display: "inline-flex",
-                              alignItems: "center",
-                              gap: 6,
-                              fontWeight: 700,
-                              cursor: "pointer",
-                            }}
-                          >
-                            <Hash size={13} />
-                            Copy tags
-                          </button>
+                            Open caption
+                          </div>
+                        </summary>
+                        <div
+                          style={{
+                            borderTop: `1px solid ${t.borderSub}`,
+                            padding: 14,
+                            display: "grid",
+                            gap: 12,
+                          }}
+                        >
+                          <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.65 }}>
+                            {suggestion.caption}
+                          </div>
+                          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                            {suggestion.hashtags.slice(0, 6).map((hashtag) => (
+                              <span
+                                key={hashtag}
+                                style={{
+                                  borderRadius: 999,
+                                  border: `1px solid ${t.borderSub}`,
+                                  background: "transparent",
+                                  color: t.textSub,
+                                  fontSize: 11,
+                                  fontWeight: 700,
+                                  padding: "5px 9px",
+                                }}
+                              >
+                                {hashtag}
+                              </span>
+                            ))}
+                          </div>
+                          <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.6 }}>
+                            {suggestion.repurpose_angle}
+                          </div>
+                          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                            <button
+                              type="button"
+                              onClick={() => void handleCopyPlanning(buildPlanningPostCopy(suggestion), "Post")}
+                              style={{
+                                border: "none",
+                                borderRadius: 999,
+                                background: `linear-gradient(135deg, ${t.accent}, ${t.accentLt})`,
+                                color: "#fff",
+                                padding: "8px 12px",
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: 6,
+                                fontWeight: 800,
+                                cursor: "pointer",
+                              }}
+                            >
+                              <Copy size={13} />
+                              Copy post
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void handleCopyPlanning(suggestion.caption, "Caption")}
+                              style={{
+                                border: `1px solid ${t.borderSub}`,
+                                borderRadius: 999,
+                                background: "transparent",
+                                color: t.textSub,
+                                padding: "8px 12px",
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: 6,
+                                fontWeight: 700,
+                                cursor: "pointer",
+                              }}
+                            >
+                              <Copy size={13} />
+                              Caption
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void handleCopyPlanning(suggestion.hashtags.join(" "), "Hashtags")}
+                              style={{
+                                border: `1px solid ${t.borderSub}`,
+                                borderRadius: 999,
+                                background: "transparent",
+                                color: t.textSub,
+                                padding: "8px 12px",
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: 6,
+                                fontWeight: 700,
+                                cursor: "pointer",
+                              }}
+                            >
+                              <Hash size={13} />
+                              Hashtags
+                            </button>
+                          </div>
                         </div>
-                      </article>
+                      </details>
                     ))}
                   </div>
                 )}
               </section>
+
 
               <div
                 style={{
@@ -2335,10 +2413,10 @@ function ClipsPageContent() {
             <section
               className="ic-premium-card"
               style={{
-                borderRadius: 24,
+                borderRadius: 20,
                 background: t.card,
                 border: `1px solid ${t.border}`,
-                padding: 20,
+                padding: 18,
               }}
             >
               {loadingClips ? (
@@ -2448,8 +2526,8 @@ function ClipsPageContent() {
                 <div
                   style={{
                     display: "grid",
-                    gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 300px), 1fr))",
-                    gap: 16,
+                    gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 280px), 1fr))",
+                    gap: 14,
                     alignItems: "start",
                   }}
                 >
@@ -2507,39 +2585,37 @@ function ClipsPageContent() {
                         key={clip.id}
                         className="lift-card ic-premium-card ic-clip-card"
                         style={{
-                          borderRadius: 22,
+                          borderRadius: 18,
                           overflow: "hidden",
-                          border: `1px solid ${t.borderSub}`,
-                          background: t.cardAlt,
+                          border: `1px solid ${t.border}`,
+                          background: t.card,
                           alignSelf: "start",
                         }}
                       >
                         <div
                           className="ic-clip-media"
                           style={{
-                            minHeight: 190,
-                            background: dark
-                              ? "radial-gradient(circle at top left, rgba(163,208,107,.22), transparent 32%), linear-gradient(135deg, #152412, #385530)"
-                              : "radial-gradient(circle at top left, rgba(255,255,255,.72), transparent 34%), linear-gradient(135deg, #dfead7, #c9ddbd)",
+                            background: dark ? "rgba(255,255,255,.025)" : "rgba(246,250,240,.82)",
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "center",
-                            padding: 16,
+                            padding: 12,
+                            borderBottom: `1px solid ${t.borderSub}`,
                           }}
                         >
                           {isPreviewable(previewUrl) ? (
                             <div
                               style={{
                                 width: "100%",
-                                maxWidth: portraitPreview ? 250 : "100%",
+                                maxWidth: portraitPreview ? 220 : 320,
                                 aspectRatio: previewAspectRatio,
                                 margin: "0 auto",
-                                borderRadius: 18,
+                                borderRadius: 14,
                                 overflow: "hidden",
                                 background: "#000",
                                 boxShadow: dark
-                                  ? "0 14px 30px rgba(0,0,0,.34)"
-                                  : "0 14px 30px rgba(20,34,16,.14)",
+                                  ? "0 10px 22px rgba(0,0,0,.28)"
+                                  : "0 10px 22px rgba(20,34,16,.12)",
                               }}
                             >
                               <video
@@ -2569,24 +2645,38 @@ function ClipsPageContent() {
                         <div style={{ padding: 16 }}>
                           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, marginBottom: 12, alignItems: "flex-start" }}>
                             <div style={{ minWidth: 0 }}>
-                              <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: ".18em", color: t.textFaint }}>
-                                {clip.podcast_title} / Clip {clip.clip_number}
+                              <div style={{ fontSize: 12, color: t.textSub, marginBottom: 6 }}>
+                                Clip {clip.clip_number}
                               </div>
-                              <div style={{ fontSize: 13, color: t.textSub, marginTop: 6 }}>
+                              <div
+                                style={{
+                                  fontSize: 15,
+                                  fontWeight: 800,
+                                  color: t.text,
+                                  lineHeight: 1.35,
+                                  display: "-webkit-box",
+                                  WebkitLineClamp: 2,
+                                  WebkitBoxOrient: "vertical",
+                                  overflow: "hidden",
+                                }}
+                              >
+                                {clip.podcast_title}
+                              </div>
+                              <div style={{ fontSize: 12, color: t.textSub, marginTop: 7 }}>
                                 {formatTime(clip.clip_start_seconds)} - {formatTime(clip.clip_end_seconds)} / {formatTime(clip.duration_seconds)}
                               </div>
-                              <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 10 }}>
+                              <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 10 }}>
                                 <span
                                   style={{
                                     borderRadius: 999,
                                     background: clip.published ? t.chip : "transparent",
                                     border: `1px solid ${clip.published ? t.accent : t.borderSub}`,
                                     color: clip.published ? t.accent : t.textSub,
-                                    fontSize: 11,
+                                    fontSize: 10,
                                     fontWeight: 700,
-                                    letterSpacing: ".1em",
+                                    letterSpacing: ".08em",
                                     textTransform: "uppercase",
-                                    padding: "6px 10px",
+                                    padding: "5px 8px",
                                   }}
                                 >
                                   {clip.published ? "Published" : "Private"}
@@ -2594,46 +2684,14 @@ function ClipsPageContent() {
                                 <span
                                   style={{
                                     borderRadius: 999,
-                                    background: overlayBadgeBackground,
-                                    border: `1px solid ${overlayBadgeBorder}`,
-                                    color: overlayBadgeColor,
-                                    fontSize: 11,
-                                    fontWeight: 700,
-                                    letterSpacing: ".1em",
-                                    textTransform: "uppercase",
-                                    padding: "6px 10px",
-                                  }}
-                                >
-                                  {overlayState.badge}
-                                </span>
-                                {overlayState.category ? (
-                                  <span
-                                    style={{
-                                      borderRadius: 999,
-                                      background: "transparent",
-                                      border: `1px solid ${t.borderSub}`,
-                                      color: t.textSub,
-                                      fontSize: 11,
-                                      fontWeight: 700,
-                                      letterSpacing: ".1em",
-                                      textTransform: "uppercase",
-                                      padding: "6px 10px",
-                                    }}
-                                  >
-                                    {overlayState.category}
-                                  </span>
-                                ) : null}
-                                <span
-                                  style={{
-                                    borderRadius: 999,
                                     background: audioBadgeBackground,
                                     border: `1px solid ${audioBadgeBorder}`,
                                     color: audioBadgeColor,
-                                    fontSize: 11,
+                                    fontSize: 10,
                                     fontWeight: 700,
-                                    letterSpacing: ".1em",
+                                    letterSpacing: ".08em",
                                     textTransform: "uppercase",
-                                    padding: "6px 10px",
+                                    padding: "5px 8px",
                                   }}
                                 >
                                   {audioFeedback.badge}
@@ -2641,33 +2699,33 @@ function ClipsPageContent() {
                                 <span
                                   style={{
                                     borderRadius: 999,
-                                    background: "transparent",
-                                    border: `1px solid ${t.borderSub}`,
-                                    color: t.textSub,
-                                    fontSize: 11,
+                                    background: overlayBadgeBackground,
+                                    border: `1px solid ${overlayBadgeBorder}`,
+                                    color: overlayBadgeColor,
+                                    fontSize: 10,
                                     fontWeight: 700,
-                                    letterSpacing: ".1em",
+                                    letterSpacing: ".08em",
                                     textTransform: "uppercase",
-                                    padding: "6px 10px",
+                                    padding: "5px 8px",
                                   }}
                                 >
-                                  {clip.status}
+                                  {overlayState.variant === "enabled" ? "B-roll" : clip.status}
                                 </span>
                               </div>
                             </div>
                             <div
                               style={{
-                                borderRadius: 18,
+                                borderRadius: 14,
                                 background: t.chip,
                                 color: t.accent,
                                 fontWeight: 700,
-                                padding: "9px 10px",
+                                padding: "8px 10px",
                                 height: "fit-content",
-                                minWidth: 72,
+                                minWidth: 64,
                                 textAlign: "center",
                               }}
                             >
-                              <div style={{ fontSize: 18, lineHeight: 1 }}>{clip.virality_score.toFixed(1)}</div>
+                              <div style={{ fontSize: 17, lineHeight: 1 }}>{clip.virality_score.toFixed(1)}</div>
                               <div style={{ marginTop: 5 }} className="ic-score-bar">
                                 <div
                                   className="ic-score-fill"
@@ -2678,24 +2736,14 @@ function ClipsPageContent() {
                           </div>
 
                           <div style={{ marginTop: 2 }}>
-                            <div
-                              style={{
-                                fontSize: 11,
-                                letterSpacing: ".16em",
-                                textTransform: "uppercase",
-                                color: t.textFaint,
-                                marginBottom: 8,
-                              }}
-                            >
-                              Clip Preview
-                            </div>
                             <p
                               style={{
                                 margin: 0,
-                                color: t.text,
-                                lineHeight: 1.7,
+                                color: t.textSub,
+                                fontSize: 13,
+                                lineHeight: 1.65,
                                 display: "-webkit-box",
-                                WebkitLineClamp: 5,
+                                WebkitLineClamp: 3,
                                 WebkitBoxOrient: "vertical",
                                 overflow: "hidden",
                               }}
@@ -2705,20 +2753,41 @@ function ClipsPageContent() {
                             </p>
                           </div>
 
+                          <details
+                            style={{
+                              marginTop: 14,
+                            }}
+                          >
+                            <summary
+                              style={{
+                                cursor: "pointer",
+                                borderRadius: 999,
+                                border: `1px solid ${t.borderSub}`,
+                                background: dark ? "rgba(255,255,255,.025)" : "rgba(255,255,255,.64)",
+                                color: t.textSub,
+                                padding: "9px 12px",
+                                fontSize: 12,
+                                fontWeight: 800,
+                                listStyle: "none",
+                                width: "fit-content",
+                              }}
+                            >
+                              Details
+                            </summary>
                           <div
                             style={{
                               display: "grid",
                               gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 220px), 1fr))",
-                              gap: 12,
-                              marginTop: 14,
+                              gap: 10,
+                              marginTop: 12,
                             }}
                           >
                             <div
                               style={{
-                                borderRadius: 16,
+                                borderRadius: 14,
                                 border: `1px solid ${t.borderSub}`,
                                 background: t.chip,
-                                padding: "12px 14px",
+                                padding: "11px 12px",
                               }}
                             >
                               <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
@@ -2738,7 +2807,7 @@ function ClipsPageContent() {
 
                             <div
                               style={{
-                                borderRadius: 16,
+                                borderRadius: 14,
                                 border: `1px solid ${t.borderSub}`,
                                 background:
                                   audioFeedback.tone === "enabled"
@@ -2746,7 +2815,7 @@ function ClipsPageContent() {
                                     : audioFeedback.tone === "failed"
                                       ? t.errorBg
                                       : "transparent",
-                                padding: "12px 14px",
+                                padding: "11px 12px",
                               }}
                             >
                               <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
@@ -2774,10 +2843,10 @@ function ClipsPageContent() {
 
                             <div
                               style={{
-                                borderRadius: 16,
+                                borderRadius: 14,
                                 border: `1px solid ${t.borderSub}`,
                                 background: overlayState.variant === "enabled" ? t.chip : "transparent",
-                                padding: "12px 14px",
+                                padding: "11px 12px",
                               }}
                             >
                               <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
@@ -2865,10 +2934,10 @@ function ClipsPageContent() {
 
                             <div
                               style={{
-                                borderRadius: 16,
+                                borderRadius: 14,
                                 border: `1px solid ${t.borderSub}`,
                                 background: "transparent",
-                                padding: "12px 14px",
+                                padding: "11px 12px",
                               }}
                             >
                               <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>
@@ -2894,10 +2963,10 @@ function ClipsPageContent() {
 
                             <div
                               style={{
-                                borderRadius: 16,
+                                borderRadius: 14,
                                 border: `1px solid ${t.borderSub}`,
                                 background: clipPlanningSuggestions.length > 0 ? t.chip : "transparent",
-                                padding: "12px 14px",
+                                padding: "11px 12px",
                               }}
                             >
                               <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
@@ -2948,25 +3017,88 @@ function ClipsPageContent() {
                               }}
                             >
                               {clipPlanningSuggestions.map((suggestion) => (
-                                <div
+                                <details
                                   key={`${clip.id}-${suggestion.platform}`}
                                   style={{
                                     borderRadius: 16,
                                     border: `1px solid ${t.borderSub}`,
                                     background: "transparent",
-                                    padding: "12px 14px",
+                                    overflow: "hidden",
                                   }}
                                 >
-                                  <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", marginBottom: 8 }}>
-                                    <div>
-                                      <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint }}>
-                                        {formatPlatformLabel(suggestion.platform)}
+                                  <summary
+                                    style={{
+                                      listStyle: "none",
+                                      cursor: "pointer",
+                                      padding: "12px 14px",
+                                    }}
+                                  >
+                                    <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                                      <div>
+                                        <div style={{ fontSize: 11, letterSpacing: ".16em", textTransform: "uppercase", color: t.textFaint }}>
+                                          {formatPlatformLabel(suggestion.platform)}
+                                        </div>
+                                        <div style={{ marginTop: 4, fontSize: 13, fontWeight: 800, color: t.text }}>
+                                          Day {suggestion.scheduled_day} at {suggestion.best_time_local}
+                                        </div>
                                       </div>
-                                      <div style={{ marginTop: 4, fontSize: 13, fontWeight: 700, color: t.text }}>
-                                        Day {suggestion.scheduled_day} at {suggestion.best_time_local}
+                                      <div style={{ borderRadius: 999, border: `1px solid ${t.borderSub}`, color: t.textSub, padding: "6px 9px", fontSize: 11, fontWeight: 800, height: "fit-content" }}>
+                                        Open
                                       </div>
                                     </div>
+                                  </summary>
+                                  <div
+                                    style={{
+                                      borderTop: `1px solid ${t.borderSub}`,
+                                      padding: "12px 14px",
+                                      display: "grid",
+                                      gap: 10,
+                                    }}
+                                  >
+                                    <div style={{ fontSize: 13, color: t.textSub, lineHeight: 1.65 }}>
+                                      {suggestion.caption}
+                                    </div>
                                     <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                                      {suggestion.hashtags.slice(0, 6).map((hashtag) => (
+                                        <span
+                                          key={hashtag}
+                                          style={{
+                                            borderRadius: 999,
+                                            border: `1px solid ${t.borderSub}`,
+                                            color: t.textSub,
+                                            padding: "5px 9px",
+                                            fontSize: 11,
+                                            fontWeight: 700,
+                                          }}
+                                        >
+                                          {hashtag}
+                                        </span>
+                                      ))}
+                                    </div>
+                                    <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.6 }}>
+                                      {suggestion.repurpose_angle}
+                                    </div>
+                                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                                      <button
+                                        type="button"
+                                        onClick={() => void handleCopyPlanning(buildPlanningPostCopy(suggestion), "Post")}
+                                        className="ic-action"
+                                        style={{
+                                          border: "none",
+                                          borderRadius: 999,
+                                          background: `linear-gradient(135deg, ${t.accent}, ${t.accentLt})`,
+                                          color: "#fff",
+                                          padding: "8px 12px",
+                                          display: "inline-flex",
+                                          alignItems: "center",
+                                          gap: 6,
+                                          fontWeight: 800,
+                                          cursor: "pointer",
+                                        }}
+                                      >
+                                        <Copy size={13} />
+                                        Post
+                                      </button>
                                       <button
                                         type="button"
                                         onClick={() => void handleCopyPlanning(suggestion.caption, "Caption")}
@@ -3009,16 +3141,11 @@ function ClipsPageContent() {
                                       </button>
                                     </div>
                                   </div>
-                                  <div style={{ fontSize: 13, color: t.textSub, lineHeight: 1.65 }}>
-                                    {truncateText(suggestion.caption, 180)}
-                                  </div>
-                                  <div style={{ marginTop: 8, fontSize: 12, color: t.textSub, lineHeight: 1.6 }}>
-                                    {suggestion.repurpose_angle}
-                                  </div>
-                                </div>
+                                </details>
                               ))}
                             </div>
                           ) : null}
+                          </details>
 
                           <div style={{ display: "flex", gap: 10, flexWrap: "wrap", justifyContent: "flex-end", marginTop: 16 }}>
                             {clip.published ? (
@@ -3100,7 +3227,7 @@ function ClipsPageContent() {
               )}
             </section>
                 </div>
-              ) : (
+              ) : mode === "generate" ? null : (
                 <section
                   style={{
                     borderRadius: 24,
@@ -3135,7 +3262,7 @@ function ClipsPageContent() {
                       type="button"
                       onClick={() => {
                         if (clips.length > 0) {
-                          setWorkspaceView("results");
+                          router.push(resultsPath);
                           return;
                         }
                         void handleGenerateClips();
@@ -3190,7 +3317,7 @@ function ClipsPageContent() {
 export default function ClipsPage() {
   return (
     <Suspense fallback={null}>
-      <ClipsPageContent />
+      <ClipsPageContent mode="generate" />
     </Suspense>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -83,7 +83,7 @@ function NavItem({ icon: Icon, label, href, active, t, collapsed }:
         <span style={{
           fontSize: 13, fontWeight: active ? 600 : 400,
           color: active ? t.text : t.textSub,
-          letterSpacing: "-.01em",
+          letterSpacing: "0",
         }}>{label}</span>
       )}
       {active && !collapsed && (
@@ -102,7 +102,7 @@ function StatCard({ icon: Icon, label, value, sub, accent, t, delay }:
   { icon: React.ElementType; label: string; value: string|number; sub: string; accent: string; t: DashboardTheme; delay: number }) {
   return (
     <div style={{
-      padding: "22px 24px", borderRadius: 18,
+      padding: "18px 20px", borderRadius: 14,
       border: `1px solid ${t.border}`,
       background: t.card,
       backdropFilter: "blur(20px)",
@@ -110,24 +110,18 @@ function StatCard({ icon: Icon, label, value, sub, accent, t, delay }:
       animation: `slideUp .55s ${delay}s cubic-bezier(.22,1,.36,1) both`,
     }}>
       <div style={{
-        position: "absolute", top: -30, right: -30,
-        width: 100, height: 100, borderRadius: "50%",
-        background: `${accent}18`, filter: "blur(24px)",
-        pointerEvents: "none",
-      }}/>
-      <div style={{
-        width: 38, height: 38, borderRadius: 11,
+        width: 36, height: 36, borderRadius: 10,
         background: `${accent}16`,
         border: `1px solid ${accent}28`,
         display: "flex", alignItems: "center", justifyContent: "center",
-        marginBottom: 16,
+        marginBottom: 14,
       }}>
         <Icon size={17} color={accent} strokeWidth={1.8}/>
       </div>
       <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint, marginBottom: 6 }}>{label}</div>
       <div style={{
         fontFamily: "'DM Serif Display', serif",
-        fontSize: 32, fontStyle: "italic",
+        fontSize: 30, fontStyle: "italic",
         color: t.text, lineHeight: 1, marginBottom: 4,
       }}>{value}</div>
       <div style={{ fontSize: 12, color: t.textSub }}>{sub}</div>
@@ -335,7 +329,7 @@ export default function DashboardPage() {
           description: `${podcast.title} has ${analysis.total_scored_segments} scored moments ready for clips.`,
           tone: "success",
           ctaHref: `/clips?podcastId=${podcast.id}`,
-          ctaLabel: "Open clips",
+          ctaLabel: "Generate clips",
         });
       }
     });
@@ -450,17 +444,17 @@ export default function DashboardPage() {
         .pc   { animation: slideUp .5s calc(var(--i)*.07s + .35s) cubic-bezier(.22,1,.36,1) both; }
 
         .nav-link:hover { background: rgba(90,158,58,.08) !important; }
-        .icon-btn:hover { background: rgba(90,158,58,.1) !important; transform: scale(1.06); }
+        .icon-btn:hover { background: rgba(90,158,58,.1) !important; transform: translateY(-1px); }
         .icon-btn { transition: all .2s cubic-bezier(.34,1.56,.64,1) !important; }
 
-        .stat-card:hover { transform: translateY(-4px) !important; box-shadow: 0 16px 44px rgba(0,0,0,.13) !important; }
+        .stat-card:hover { transform: translateY(-2px) !important; box-shadow: 0 14px 34px rgba(0,0,0,.1) !important; }
         .stat-card { transition: transform .3s cubic-bezier(.22,1,.36,1), box-shadow .3s !important; }
 
         .pod-item { transition: transform .28s cubic-bezier(.22,1,.36,1), box-shadow .28s; }
-        .pod-item:hover { transform: translateY(-4px); box-shadow: 0 14px 36px rgba(0,0,0,.12); }
+        .pod-item:hover { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(0,0,0,.1); }
 
         .sidebar-link { transition: all .2s; }
-        .sidebar-link:hover { background: rgba(90,158,58,.08) !important; transform: translateX(3px); }
+        .sidebar-link:hover { background: rgba(90,158,58,.08) !important; transform: translateX(1px); }
 
         .upload-btn {
           transition: transform .25s cubic-bezier(.34,1.56,.64,1), box-shadow .25s;
@@ -472,7 +466,7 @@ export default function DashboardPage() {
           background-size:250%; background-position:200%;
           transition: background-position .5s;
         }
-        .upload-btn:hover { transform: translateY(-3px); box-shadow: 0 18px 40px rgba(90,158,58,.38) !important; }
+        .upload-btn:hover { transform: translateY(-2px); box-shadow: 0 14px 32px rgba(90,158,58,.26) !important; }
         .upload-btn:hover::after { background-position:-50%; }
         .upload-btn:active { transform: scale(.97); }
 
@@ -542,7 +536,7 @@ export default function DashboardPage() {
         )}
 
         <aside style={{
-          width: isMobile ? 240 : (collapsed ? 68 : 240),
+          width: isMobile ? 236 : (collapsed ? 68 : 236),
           minHeight: "100vh",
           position: "fixed", top: 0, left: 0, zIndex: 50,
           background: t.sidebar,
@@ -551,11 +545,11 @@ export default function DashboardPage() {
           transition: "width .35s cubic-bezier(.22,1,.36,1), transform .3s cubic-bezier(.22,1,.36,1)",
           overflow: "hidden",
           transform: isMobile ? (mobileNavOpen ? "translateX(0)" : "translateX(-100%)") : "translateX(0)",
-          boxShadow: isMobile && mobileNavOpen ? "0 24px 60px rgba(0,0,0,.24)" : "none",
+          boxShadow: isMobile && mobileNavOpen ? "0 18px 42px rgba(0,0,0,.22)" : "none",
         }}>
           {/* Logo */}
           <div style={{
-            padding: collapsed ? "22px 14px" : "24px 20px",
+            padding: collapsed ? "20px 14px" : "22px 18px",
             borderBottom: `1px solid ${t.borderSub}`,
             display: "flex", alignItems: "center",
             gap: 12, justifyContent: collapsed ? "center" : "flex-start",
@@ -569,7 +563,7 @@ export default function DashboardPage() {
               style={{
                 width: 34,
                 height: 34,
-                borderRadius: 10,
+                borderRadius: 8,
                 flexShrink: 0,
                 boxShadow: `0 4px 16px ${t.accentGlow}`,
               }}
@@ -583,7 +577,7 @@ export default function DashboardPage() {
           </div>
 
           {/* Nav */}
-          <nav style={{ flex: 1, padding: "16px 10px", display: "flex", flexDirection:"column", gap: 3 }}>
+          <nav style={{ flex: 1, padding: "14px 10px", display: "flex", flexDirection:"column", gap: 4 }}>
             <NavItem icon={LayoutDashboard} label="Overview"  href="/dashboard" active t={t} collapsed={collapsed}/>
             <NavItem icon={Library}         label="Library"   href="/podcasts"  t={t} collapsed={collapsed}/>
             <NavItem icon={BarChart2}       label="Analytics" href="/analytics" t={t} collapsed={collapsed}/>
@@ -593,7 +587,7 @@ export default function DashboardPage() {
 
           {/* Profile + sign out */}
           <div style={{
-            padding: collapsed ? "16px 10px" : "16px 14px",
+            padding: collapsed ? "14px 10px" : "14px 12px",
             borderTop: `1px solid ${t.borderSub}`,
             display: "flex", flexDirection:"column", gap: 10,
           }}>
@@ -601,8 +595,8 @@ export default function DashboardPage() {
             {!collapsed && profile && (
               <div style={{
                 display:"flex", alignItems:"center", gap: 10,
-                padding: "10px 12px", borderRadius: 12,
-                background: `rgba(90,158,58,.06)`,
+                padding: "9px 10px", borderRadius: 10,
+                background: `rgba(90,158,58,.05)`,
                 border: `1px solid ${t.borderSub}`,
               }}>
                 <div style={{
@@ -626,8 +620,9 @@ export default function DashboardPage() {
             <button onClick={() => void signOut()} style={{
               display:"flex", alignItems:"center", justifyContent: collapsed?"center":"flex-start", gap: 8,
               padding: "9px 12px", borderRadius: 10,
-              background:"transparent", border:`1px solid ${t.redBord}`,
-              color: t.red, fontSize: 13, fontWeight: 500, cursor:"pointer",
+              background: dark ? "rgba(90,158,58,.04)" : "rgba(255,255,255,.42)",
+              border:`1px solid ${t.borderSub}`,
+              color: t.textSub, fontSize: 13, fontWeight: 600, cursor:"pointer",
               fontFamily:"'DM Sans',sans-serif",
               transition: "all .2s",
             }}>
@@ -639,7 +634,7 @@ export default function DashboardPage() {
 
         {/* ═══════════════════════ MAIN AREA ═══════════════════════ */}
         <div style={{
-          marginLeft: isMobile ? 0 : (collapsed ? 68 : 240),
+          marginLeft: isMobile ? 0 : (collapsed ? 68 : 236),
           flex: 1, minHeight:"100vh",
           display:"flex", flexDirection:"column",
           transition:"margin-left .35s cubic-bezier(.22,1,.36,1)",
@@ -878,20 +873,20 @@ export default function DashboardPage() {
           </header>
 
           {/* ── PAGE CONTENT ── */}
-          <main style={{ padding: isMobile ? "20px 16px 40px" : "32px 32px 60px", flex:1 }}>
+          <main style={{ padding: isMobile ? "18px 14px 38px" : "28px 28px 56px", flex:1 }}>
 
             {/* Welcome row */}
             <section
               className="ic-premium-card"
               style={{
-                marginBottom: 28,
-                borderRadius: 28,
+                marginBottom: 22,
+                borderRadius: 22,
                 border: `1px solid ${t.border}`,
                 background: dark
                   ? "linear-gradient(135deg, rgba(18,30,14,.96), rgba(12,18,10,.92))"
                   : "linear-gradient(135deg, rgba(255,255,255,.96), rgba(244,248,236,.98))",
-                padding: isMobile ? "22px 18px" : "28px",
-                boxShadow: dark ? "0 28px 70px rgba(0,0,0,.2)" : "0 28px 70px rgba(90,158,58,.08)",
+                padding: isMobile ? "20px 16px" : "24px",
+                boxShadow: dark ? "0 18px 46px rgba(0,0,0,.18)" : "0 18px 46px rgba(90,158,58,.07)",
                 animation: "slideUp .55s .08s cubic-bezier(.22,1,.36,1) both",
               }}
             >
@@ -928,7 +923,7 @@ export default function DashboardPage() {
                     <h1 style={{
                       fontFamily: "'DM Serif Display', serif",
                       fontSize: "clamp(30px, 3.6vw, 46px)",
-                      fontStyle: "italic", letterSpacing: "-.045em",
+                      fontStyle: "italic", letterSpacing: "0",
                       lineHeight: 1.04, marginBottom: 10,
                     }}>
                       {firstName ? (
@@ -937,7 +932,7 @@ export default function DashboardPage() {
                         <span className="shimmer-name">Welcome to InsightClips</span>
                       )}
                     </h1>
-                    <p style={{ fontSize: 15, color: t.textSub, lineHeight: 1.75, maxWidth: 680 }}>
+                    <p style={{ fontSize: 14, color: t.textSub, lineHeight: 1.7, maxWidth: 680 }}>
                       {workspaceEpisodes > 0
                         ? analytics && analytics.total_clips > 0
                           ? `${analytics.total_clips} generated clip${analytics.total_clips !== 1 ? "s" : ""} across ${analytics.total_podcasts} tracked episode${analytics.total_podcasts !== 1 ? "s" : ""}, with ${analytics.published_clips} already published and ${visibilityTotal} total reach.`
@@ -1007,7 +1002,7 @@ export default function DashboardPage() {
             <section
               className="ic-premium-card"
               style={{
-                marginBottom: 28,
+                marginBottom: 22,
                 borderRadius: 22,
                 border: `1px solid ${t.border}`,
                 background: dark ? "rgba(255,255,255,.035)" : "rgba(255,255,255,.76)",
@@ -1065,7 +1060,7 @@ export default function DashboardPage() {
             <div style={{
               display:"grid",
               gridTemplateColumns: "repeat(auto-fit,minmax(min(100%,190px),1fr))",
-              gap: 16, marginBottom: 28,
+              gap: 14, marginBottom: 22,
             }}>
               <div className="stat-card">
                 <StatCard icon={Mic2}       label="Podcasts"   value={analytics?.total_podcasts ?? safePodcasts.length} sub="total uploaded"          accent="#5a9e3a"  t={t} delay={.10}/>
@@ -1172,9 +1167,9 @@ export default function DashboardPage() {
                   {[
                     { id:"upload",    icon:Plus,      label:"Upload or import",  sub:"File upload or YouTube link",      href:"/upload" },
                     { id:"podcasts",  icon:Library,   label:"Browse podcasts", sub:"Search your library",  href:"/podcasts" },
-                    { id:"clips",     icon:Play,      label:"View clips",      sub:"Open discovery flow",  href:"/clips" },
+                    { id:"clips",     icon:Play,      label:"Generate clips",  sub:"Choose options first", href:"/clips" },
                     { id:"analytics", icon:BarChart2, label:"View analytics",  sub:"Performance summary",  href:"/analytics" },
-                    { id:"planning",  icon:Sparkles,  label:"Open planning",   sub:"Calendar and hashtags", href:"/clips" },
+                    { id:"planning",  icon:Sparkles,  label:"Open results",    sub:"Generated videos",     href:"/clips/generated" },
                     { id:"feedback",  icon:Settings,  label:"Share feedback",  sub:"Support and contact",  href:"/settings" },
                   ].map(({ id, icon:Icon, label, sub, href }) => (
                     <Link key={id} href={href} className="sidebar-link ic-premium-card" style={{
@@ -1243,16 +1238,6 @@ export default function DashboardPage() {
                     </div>
                     <div style={{ display:"flex", alignItems:"center", gap:8, width:isMobile ? "100%" : "auto", justifyContent:isMobile ? "space-between" : "flex-end" }}>
                       <div style={{ display:"flex", alignItems:"center", gap:8, flexWrap:"wrap", justifyContent:isMobile ? "space-between" : "flex-end" }}>
-                        <button onClick={() => router.push("/upload")} className="upload-btn" style={{
-                        display:"flex", alignItems:"center", gap:6,
-                        padding:"8px 18px", borderRadius:100, border:"none",
-                        background:`linear-gradient(135deg,${dark?"#3d6e24":"#4a8e2a"},${t.accent})`,
-                        color:"#fff", fontSize:12, fontWeight:600,
-                        cursor:"pointer", fontFamily:"'DM Sans',sans-serif",
-                        boxShadow:`0 4px 16px ${t.accentGlow}`,
-                      }}>
-                          <Plus size={13} strokeWidth={2.5}/> Upload file
-                        </button>
                         <Link href="/upload/youtube" style={{
                           display:"inline-flex", alignItems:"center", gap:6,
                           padding:"8px 14px", borderRadius:100,

--- a/frontend/app/demo/page.tsx
+++ b/frontend/app/demo/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { ArrowLeft, CheckCircle2, PlayCircle, Sparkles, Wand2 } from "lucide-react";
 
 const palette = {
@@ -34,6 +35,8 @@ const steps = [
 ];
 
 export default function DemoPage() {
+  const [videoAvailable, setVideoAvailable] = useState(true);
+
   return (
     <main
       style={{
@@ -121,7 +124,7 @@ export default function DemoPage() {
             </h1>
 
             <p style={{ color: palette.textMuted, fontSize: 17, lineHeight: 1.7, maxWidth: 540 }}>
-              This page gives you a clean demo flow: first the simple product steps, then a real finished clip you can play right away.
+              This page gives you a clean demo flow: first the product steps, then the clip preview slot used during the presentation.
             </p>
 
             <div style={{ display: "grid", gap: 14, marginTop: 28 }}>
@@ -184,21 +187,85 @@ export default function DemoPage() {
               </h2>
             </div>
 
-            <video
-              controls
-              preload="metadata"
-              style={{
-                width: "100%",
-                borderRadius: 22,
-                border: `1px solid ${palette.border}`,
-                background: "#000",
-                minHeight: 520,
-                objectFit: "cover",
-              }}
-            >
-              <source src="/demo/finished-clip.mp4" type="video/mp4" />
-              Your browser does not support the demo video.
-            </video>
+            {videoAvailable ? (
+              <video
+                controls
+                preload="metadata"
+                onError={() => setVideoAvailable(false)}
+                style={{
+                  width: "100%",
+                  borderRadius: 22,
+                  border: `1px solid ${palette.border}`,
+                  background: "#000",
+                  minHeight: 520,
+                  objectFit: "cover",
+                }}
+              >
+                <source
+                  src="/demo/finished-clip.mp4"
+                  type="video/mp4"
+                  onError={() => setVideoAvailable(false)}
+                />
+                Your browser does not support the demo video.
+              </video>
+            ) : (
+              <div
+                style={{
+                  minHeight: 520,
+                  borderRadius: 22,
+                  border: `1px solid ${palette.border}`,
+                  background:
+                    "linear-gradient(180deg, rgba(163,208,107,0.12), rgba(0,0,0,0.28)), #080b06",
+                  display: "grid",
+                  alignContent: "center",
+                  gap: 18,
+                  padding: 28,
+                  textAlign: "center",
+                }}
+              >
+                <div
+                  style={{
+                    width: 72,
+                    height: 72,
+                    borderRadius: 24,
+                    margin: "0 auto",
+                    background: "rgba(163,208,107,0.12)",
+                    border: `1px solid ${palette.border}`,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: palette.accent,
+                  }}
+                >
+                  <PlayCircle size={32} />
+                </div>
+                <div>
+                  <div style={{ fontFamily: "'DM Serif Display', serif", fontSize: 34, lineHeight: 1.05 }}>
+                    Demo clip slot ready
+                  </div>
+                  <p style={{ margin: "12px auto 0", maxWidth: 420, color: palette.textMuted, lineHeight: 1.7 }}>
+                    The final clip preview is not loaded in this environment. The walkthrough still gives you a clean presentation path until the MP4 is attached.
+                  </p>
+                </div>
+                <Link
+                  href="/upload"
+                  style={{
+                    justifySelf: "center",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 8,
+                    borderRadius: 999,
+                    background: `linear-gradient(135deg, ${palette.accentDark}, ${palette.accent})`,
+                    color: "#0d1008",
+                    padding: "12px 18px",
+                    fontWeight: 800,
+                    textDecoration: "none",
+                  }}
+                >
+                  Open upload flow
+                </Link>
+              </div>
+            )}
 
             <div
               style={{
@@ -212,7 +279,7 @@ export default function DemoPage() {
                 Demo tip
               </div>
               <p style={{ margin: 0, color: palette.textMuted, lineHeight: 1.7 }}>
-                Use this page during your presentation: explain the 3-step flow on the left, then play the finished clip on the right to show the final output users get.
+                Use this page during your presentation: explain the 3-step flow on the left, then play the finished clip when the MP4 is present.
               </p>
             </div>
           </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -13,10 +13,13 @@
   --accent: #5a9e3a;
   --accent-strong: #4d8a2f;
   --accent-soft: rgba(90, 158, 58, 0.12);
+  --melon: #e7b86a;
+  --melon-soft: rgba(231, 184, 106, 0.16);
+  --melon-border: rgba(190, 134, 48, 0.24);
   --glow-a: rgba(163, 208, 107, 0.18);
   --glow-b: rgba(140, 190, 60, 0.14);
-  --shadow-soft: 0 28px 80px rgba(35, 48, 22, 0.12);
-  --shadow-strong: 0 24px 60px rgba(13, 18, 8, 0.24);
+  --shadow-soft: 0 18px 46px rgba(35, 48, 22, 0.1);
+  --shadow-strong: 0 18px 48px rgba(13, 18, 8, 0.22);
   --font-sans: var(--font-app-sans, "DM Sans", sans-serif);
   --font-serif: var(--font-app-serif, "DM Serif Display", serif);
   --font-mono: var(--font-app-mono, "JetBrains Mono", monospace);
@@ -37,8 +40,10 @@
     --surface-strong: rgba(20, 30, 15, 0.9);
     --border-soft: rgba(163, 208, 107, 0.16);
     --border-strong: rgba(163, 208, 107, 0.3);
-    --shadow-soft: 0 28px 80px rgba(0, 0, 0, 0.26);
-    --shadow-strong: 0 28px 70px rgba(0, 0, 0, 0.38);
+    --melon-soft: rgba(231, 184, 106, 0.12);
+    --melon-border: rgba(231, 184, 106, 0.2);
+    --shadow-soft: 0 18px 46px rgba(0, 0, 0, 0.24);
+    --shadow-strong: 0 20px 56px rgba(0, 0, 0, 0.34);
   }
 }
 
@@ -225,14 +230,15 @@ select {
 }
 
 .ic-premium-card:hover {
-  transform: translateY(-3px);
+  transform: translateY(-2px);
   border-color: var(--border-strong);
-  box-shadow: 0 18px 48px rgba(35, 48, 22, 0.14);
+  box-shadow: 0 14px 34px rgba(35, 48, 22, 0.12);
 }
 
 .ic-action {
   position: relative;
   overflow: hidden;
+  min-height: 2.65rem;
 }
 
 .ic-action::after {
@@ -261,6 +267,43 @@ select {
   height: 70%;
   background: radial-gradient(circle at center, rgba(163, 208, 107, 0.16), transparent 62%);
   pointer-events: none;
+}
+
+.ic-action:focus-visible,
+.ic-premium-card:focus-visible,
+.sidebar-link:focus-visible,
+.tab-btn:focus-visible,
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.sidebar-link,
+.tab-btn,
+.ic-action {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.orb1,
+.orb2,
+.orb3,
+.orbA,
+.orbB,
+.ambient-orb {
+  opacity: 0.48;
+}
+
+.ic-compact-grid {
+  align-items: stretch;
+}
+
+.ic-soft-warning {
+  border-color: var(--melon-border) !important;
+  background: var(--melon-soft) !important;
 }
 
 .ic-mobile-scroll {
@@ -473,6 +516,10 @@ select {
     transform: none;
   }
 
+  .ic-action {
+    min-height: 2.75rem;
+  }
+
   .ic-studio-steps {
     display: flex;
     gap: 0.7rem;
@@ -496,6 +543,17 @@ select {
   .ic-wizard-item {
     flex: 0 0 78%;
     scroll-snap-align: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }
 
@@ -550,5 +608,13 @@ select {
 
 input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {
+  display: none;
+}
+
+details > summary {
+  list-style: none;
+}
+
+details > summary::-webkit-details-marker {
   display: none;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { DM_Sans, DM_Serif_Display, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
-import { AuthProvider } from "@/context/AuthContext"; // Import the Authentication Context
+import { AuthRouteGuard } from "@/components/AuthRouteGuard";
+import { AuthProvider } from "@/context/AuthContext";
 
 const sans = DM_Sans({
   subsets: ["latin"],
@@ -37,11 +38,8 @@ export default function RootLayout({
   return (
     <html lang="en" data-scroll-behavior="smooth" className="h-full antialiased">
       <body className={`${sans.variable} ${serif.variable} ${mono.variable} min-h-full flex flex-col`}>
-        {/* Wrap children with AuthProvider to ensure authentication state 
-          is accessible throughout the entire application.
-        */}
         <AuthProvider>
-          {children}
+          <AuthRouteGuard>{children}</AuthRouteGuard>
         </AuthProvider>
       </body>
     </html>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -83,6 +83,13 @@ function LoginPageContent() {
   const [dark, setDark] = useState(false);
 
   const shell = getAuthTheme(dark);
+  const nextPath = useMemo(() => {
+    const candidate = searchParams.get("next") ?? "";
+    return candidate.startsWith("/") && !candidate.startsWith("//") && candidate !== "/login"
+      ? candidate
+      : "/dashboard";
+  }, [searchParams]);
+
   const successMessage = useMemo(() => {
     if (searchParams.get("registered") === "true") {
       return "Account verified. You can now sign in directly with your email and password.";
@@ -110,9 +117,9 @@ function LoginPageContent() {
 
   useEffect(() => {
     if (user) {
-      router.replace("/dashboard");
+      router.replace(nextPath);
     }
-  }, [router, user]);
+  }, [nextPath, router, user]);
 
   const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -145,7 +152,7 @@ function LoginPageContent() {
         window.localStorage.removeItem("rememberedEmail");
       }
 
-      router.replace("/dashboard");
+      router.replace(nextPath);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to sign in.");
       setLoading(false);

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -201,6 +201,10 @@ export default function ProfilePage() {
       errorBg: base.errorBg,
       errorBorder: base.errorBd,
       errorText: base.errorText,
+      deleteBg: dark ? "rgba(90,158,58,.1)" : "rgba(241,249,235,.92)",
+      deleteBorder: dark ? "rgba(130,205,110,.26)" : "rgba(130,205,110,.38)",
+      deleteText: dark ? "#bfe4ab" : "#3f7f25",
+      deleteButton: dark ? "#3c7627" : "#5a9e3a",
     };
   }, [dark]);
 
@@ -472,9 +476,9 @@ export default function ProfilePage() {
         }
       : deleteFeedback?.tone === "error"
         ? {
-            background: palette.errorBg,
-            border: palette.errorBorder,
-            color: palette.errorText,
+            background: palette.deleteBg,
+            border: palette.deleteBorder,
+            color: palette.deleteText,
           }
         : {
             background: palette.chip,
@@ -1064,27 +1068,27 @@ export default function ProfilePage() {
               style={{
                 borderRadius: 24,
                 background: palette.card,
-                border: `1px solid ${palette.errorBorder}`,
+                border: `1px solid ${palette.deleteBorder}`,
                 padding: 20,
               }}
             >
               <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
-                <Trash2 size={18} color={palette.errorText} />
-                <div style={{ fontSize: 11, letterSpacing: ".18em", textTransform: "uppercase", color: palette.errorText }}>
-                  Danger zone
+                <Trash2 size={18} color={palette.deleteText} />
+                <div style={{ fontSize: 11, letterSpacing: ".18em", textTransform: "uppercase", color: palette.deleteText }}>
+                  Account deletion
                 </div>
               </div>
 
               <div
                 style={{
                   borderRadius: 16,
-                  border: `1px solid ${palette.errorBorder}`,
-                  background: palette.errorBg,
+                  border: `1px solid ${palette.deleteBorder}`,
+                  background: palette.deleteBg,
                   padding: "12px 14px",
                   marginBottom: 12,
                   fontSize: 13,
                   lineHeight: 1.65,
-                  color: palette.errorText,
+                  color: palette.deleteText,
                 }}
               >
                 Delete account permanently removes your profile, podcasts, generated clips, source media, messages, and sign-in access.
@@ -1129,7 +1133,7 @@ export default function ProfilePage() {
                   style={{
                     border: "none",
                     borderRadius: 16,
-                    background: palette.errorText,
+                    background: palette.deleteButton,
                     color: "#fff",
                     padding: "12px 16px",
                     display: "inline-flex",

--- a/frontend/app/upload/UploadWorkspace.tsx
+++ b/frontend/app/upload/UploadWorkspace.tsx
@@ -810,10 +810,10 @@ export default function UploadWorkspace({
           <section
             className="slide-up ic-premium-card"
             style={{
-              borderRadius: 26,
+              borderRadius: 20,
               border: `1px solid ${border}`,
               background: card,
-              padding: isMobile ? "22px 18px" : "30px 28px",
+              padding: isMobile ? "20px 16px" : "26px 24px",
               marginBottom: 16,
             }}
           >
@@ -849,7 +849,7 @@ export default function UploadWorkspace({
                     fontFamily: "'DM Serif Display', serif",
                     fontSize: "clamp(30px, 4vw, 42px)",
                     lineHeight: 1.04,
-                    letterSpacing: "-.03em",
+                    letterSpacing: "0",
                   }}
                 >
                   {sourceMode === "file" ? (
@@ -865,7 +865,7 @@ export default function UploadWorkspace({
                 <p style={{ marginTop: 14, fontSize: 14, lineHeight: 1.75, color: muted }}>
                   {sourceMode === "file"
                     ? "Select a video, see duration and pricing clearly, then confirm when you are ready."
-                    : "Paste one public YouTube video and keep the same export, subtitle, and clip planning defaults used for file uploads."}
+                    : "Paste one public YouTube video and keep the same clip settings used for file uploads."}
                 </p>
               </div>
 
@@ -962,7 +962,7 @@ export default function UploadWorkspace({
           <section
             className="slide-up ic-premium-card"
             style={{
-              borderRadius: 22,
+              borderRadius: 20,
               border: `1px solid ${border}`,
               background: d ? "rgba(255,255,255,.035)" : "rgba(255,255,255,.76)",
               padding: "16px",
@@ -1039,8 +1039,8 @@ export default function UploadWorkspace({
                 </div>
                 <div style={{ fontSize: 13, color: muted, lineHeight: 1.6 }}>
                   {sourceMode === "file"
-                    ? "Choose a local file, review the pre-flight result, and continue from there."
-                    : "Paste a single YouTube video link and continue straight to import."}
+                    ? "Choose a file, run pre-flight, then continue."
+                    : "Paste one public YouTube link and import it."}
                 </div>
               </div>
               {alternateHref ? (
@@ -1071,10 +1071,10 @@ export default function UploadWorkspace({
           <section
             className="slide-up ic-premium-card"
             style={{
-              borderRadius: 22,
+              borderRadius: 20,
               border: `1px solid ${border}`,
               background: card,
-              padding: isMobile ? "20px 18px 18px" : "24px 24px 22px",
+              padding: isMobile ? "18px 16px" : "22px",
               marginBottom: 16,
             }}
           >
@@ -1385,7 +1385,7 @@ export default function UploadWorkspace({
           <section
             className="slide-up ic-premium-card"
             style={{
-              borderRadius: 18,
+              borderRadius: 16,
               border: `1px solid ${border}`,
               background: d ? "rgba(255,255,255,.035)" : "rgba(255,255,255,.74)",
               padding: "16px",
@@ -1740,14 +1740,14 @@ export default function UploadWorkspace({
                 <section
                   className="slide-up ic-premium-card"
                   style={{
-                    borderRadius: 18,
-                    border: `1px solid ${d ? "rgba(175,70,70,.35)" : "rgba(210,148,148,.55)"}`,
-                    background: d ? "rgba(44,8,8,.75)" : "rgba(255,232,232,.9)",
-                    padding: "18px 20px",
+                    borderRadius: 16,
+                    border: `1px solid ${d ? "rgba(231,184,106,.24)" : "rgba(190,134,48,.28)"}`,
+                    background: d ? "rgba(68,45,12,.36)" : "rgba(255,247,228,.94)",
+                    padding: "16px",
                     display: "flex",
                     alignItems: "flex-start",
                     gap: 12,
-                    color: d ? "#e08080" : "#934545",
+                    color: d ? "#f0c980" : "#7a541e",
                     marginBottom: 16,
                   }}
                 >
@@ -2009,25 +2009,25 @@ export default function UploadWorkspace({
               <section
                 className="slide-up ic-premium-card"
                 style={{
-                  borderRadius: 24,
+                  borderRadius: 20,
                   border: `1px solid ${border}`,
                   background: d
                     ? "linear-gradient(180deg, rgba(14,24,11,.94), rgba(10,18,8,.9))"
                     : "linear-gradient(180deg, rgba(255,255,255,.96), rgba(246,251,241,.96))",
-                  padding: "24px 24px 22px",
+                  padding: isMobile ? "18px 16px" : "22px",
                   marginBottom: 16,
                   boxShadow: d
-                    ? "0 18px 48px rgba(0,0,0,.16)"
-                    : "0 18px 42px rgba(90,158,58,.08)",
+                    ? "0 14px 36px rgba(0,0,0,.14)"
+                    : "0 14px 34px rgba(90,158,58,.07)",
                 }}
               >
-                <div style={{ display: "flex", justifyContent: "space-between", gap: 14, alignItems: "flex-start", flexWrap: "wrap", marginBottom: 20 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 14, alignItems: "flex-start", flexWrap: "wrap", marginBottom: 18 }}>
                   <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
                     <div
                       style={{
-                        width: 52,
-                        height: 52,
-                        borderRadius: 16,
+                        width: 44,
+                        height: 44,
+                        borderRadius: 12,
                         background: d ? "rgba(90,158,58,.14)" : "rgba(90,158,58,.1)",
                         border: `1px solid ${subBorder}`,
                         display: "flex",
@@ -2039,16 +2039,14 @@ export default function UploadWorkspace({
                       <Link2 size={22} color={hi} />
                     </div>
                     <div>
-                      <div style={{ fontSize: 10, letterSpacing: ".24em", textTransform: "uppercase", color: hi2, fontWeight: 700, marginBottom: 5 }}>
-                        Step 04 / Review
+                      <div style={{ fontSize: 10, letterSpacing: ".22em", textTransform: "uppercase", color: hi2, fontWeight: 700, marginBottom: 6 }}>
+                        YouTube import
                       </div>
-                      <h2 style={{ margin: 0, fontFamily: "'DM Serif Display', serif", fontStyle: "italic", fontSize: 30, fontWeight: 400, lineHeight: 1.12 }}>
-                        Bring in one video,
-                        <br />
-                        skip the noisy setup.
+                      <h2 style={{ margin: 0, fontFamily: "'DM Serif Display', serif", fontStyle: "italic", fontSize: isMobile ? 26 : 30, fontWeight: 400, lineHeight: 1.12 }}>
+                        Import one public video.
                       </h2>
-                      <p style={{ marginTop: 10, fontSize: 13, lineHeight: 1.72, color: muted, maxWidth: 560 }}>
-                        Paste a public YouTube link, import it into your library, and jump straight to analysis when it is ready.
+                      <p style={{ marginTop: 9, fontSize: 13, lineHeight: 1.65, color: muted, maxWidth: 560 }}>
+                        Paste the link, save it to your library, then analyze it from the ready state.
                       </p>
                     </div>
                   </div>
@@ -2057,10 +2055,10 @@ export default function UploadWorkspace({
                       borderRadius: 999,
                       border: `1px solid ${subBorder}`,
                       background: d ? "rgba(90,158,58,.12)" : "rgba(90,158,58,.08)",
-                      padding: "8px 12px",
-                      color: hi,
-                      fontSize: 11,
-                      fontWeight: 700,
+                    padding: "7px 11px",
+                    color: hi,
+                    fontSize: 11,
+                    fontWeight: 700,
                     }}
                   >
                     Single public video
@@ -2070,17 +2068,17 @@ export default function UploadWorkspace({
                 <div
                   style={{
                     display: "grid",
-                    gridTemplateColumns: isTablet ? "1fr" : "minmax(0, 1.12fr) minmax(260px, .88fr)",
-                    gap: 16,
+                    gridTemplateColumns: isTablet ? "1fr" : "minmax(0, 1.22fr) minmax(240px, .78fr)",
+                    gap: 14,
                     alignItems: "start",
                   }}
                 >
                   <div
                     style={{
-                      borderRadius: 20,
+                      borderRadius: 16,
                       border: `1px solid ${subBorder}`,
                       background: d ? "rgba(8,14,8,.56)" : "rgba(255,255,255,.88)",
-                      padding: "16px",
+                      padding: isMobile ? "14px" : "16px",
                     }}
                   >
                     <div style={{ display: "grid", gap: 12, marginBottom: 16 }}>
@@ -2218,16 +2216,16 @@ export default function UploadWorkspace({
                   <div style={{ display: "grid", gap: 12 }}>
                     <div
                       style={{
-                        borderRadius: 18,
+                        borderRadius: 16,
                         border: `1px solid ${subBorder}`,
                         background: d ? "rgba(10,18,8,.74)" : "rgba(248,252,244,.94)",
-                        padding: "16px",
+                        padding: "14px",
                       }}
                     >
-                      <div style={{ fontSize: 10, letterSpacing: ".2em", textTransform: "uppercase", color: hi2, fontWeight: 700, marginBottom: 10 }}>
+                      <div style={{ fontSize: 10, letterSpacing: ".18em", textTransform: "uppercase", color: hi2, fontWeight: 700, marginBottom: 10 }}>
                         Accepted links
                       </div>
-                      <div style={{ display: "grid", gap: 8 }}>
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                         {[
                           "youtube.com/watch?v=...",
                           "youtu.be/...",
@@ -2236,11 +2234,11 @@ export default function UploadWorkspace({
                           <div
                             key={item}
                             style={{
-                              borderRadius: 12,
+                              borderRadius: 999,
                               border: `1px solid ${subBorder}`,
                               background: d ? "rgba(90,158,58,.08)" : "rgba(90,158,58,.05)",
-                              padding: "10px 12px",
-                              fontSize: 12,
+                              padding: "8px 10px",
+                              fontSize: 11,
                               color: text,
                               fontFamily: "monospace",
                             }}
@@ -2253,25 +2251,42 @@ export default function UploadWorkspace({
 
                     <div
                       style={{
-                        borderRadius: 18,
+                        borderRadius: 16,
                         border: `1px solid ${subBorder}`,
                         background: d ? "rgba(10,18,8,.74)" : "rgba(248,252,244,.94)",
-                        padding: "16px",
+                        padding: "14px",
                       }}
                     >
                       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
                         <Clock size={14} color={hi} />
-                        <div style={{ fontSize: 10, letterSpacing: ".2em", textTransform: "uppercase", color: hi2, fontWeight: 700 }}>
-                          What happens next
+                        <div style={{ fontSize: 10, letterSpacing: ".18em", textTransform: "uppercase", color: hi2, fontWeight: 700 }}>
+                          Next steps
                         </div>
                       </div>
-                      <div style={{ display: "grid", gap: 8 }}>
+                      <div style={{ display: "grid", gap: 9 }}>
                         {[
-                          "We normalize the link and save one video to your podcast library.",
-                          "When import finishes, you can open clips directly from the success state.",
-                          "Playlist links are reduced to one selected video when possible.",
-                        ].map((item) => (
-                          <div key={item} style={{ fontSize: 12, color: muted, lineHeight: 1.6 }}>
+                          "Save video to library",
+                          "Analyze when ready",
+                          "Open clips workspace",
+                        ].map((item, index) => (
+                          <div key={item} style={{ display: "flex", alignItems: "center", gap: 9, fontSize: 12, color: muted, lineHeight: 1.5 }}>
+                            <span
+                              style={{
+                                width: 22,
+                                height: 22,
+                                borderRadius: 999,
+                                background: d ? "rgba(90,158,58,.12)" : "rgba(90,158,58,.08)",
+                                color: hi,
+                                display: "inline-flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                fontSize: 11,
+                                fontWeight: 800,
+                                flexShrink: 0,
+                              }}
+                            >
+                              {index + 1}
+                            </span>
                             {item}
                           </div>
                         ))}
@@ -2337,11 +2352,11 @@ export default function UploadWorkspace({
                 <section
                   className="slide-up ic-premium-card"
                   style={{
-                    borderRadius: 20,
-                    border: `1px solid ${d ? "rgba(58,158,56,.38)" : "rgba(140,215,130,.65)"}`,
-                    background: d ? "rgba(16,52,14,.9)" : "rgba(220,252,210,.92)",
-                    padding: "22px",
-                    color: "#2f7d2f",
+                    borderRadius: 18,
+                    border: `1px solid ${d ? "rgba(130,205,110,.3)" : "rgba(130,205,110,.48)"}`,
+                    background: d ? "rgba(18,48,14,.82)" : "rgba(238,250,229,.96)",
+                    padding: isMobile ? "18px 16px" : "20px",
+                    color: d ? "#c9e89a" : "#2f6f20",
                   }}
                 >
                   <div style={{ display: "flex", justifyContent: "space-between", gap: 14, alignItems: "flex-start", flexWrap: "wrap", marginBottom: 16 }}>
@@ -2364,7 +2379,7 @@ export default function UploadWorkspace({
                         <div style={{ fontSize: 10, letterSpacing: ".24em", textTransform: "uppercase", opacity: 0.72, marginBottom: 3 }}>
                           {youtubeNeedsPayment ? "Imported - payment needed" : "Imported and ready"}
                         </div>
-                        <div style={{ fontSize: 22, fontWeight: 800 }}>{youtubeImport.title}</div>
+                        <div style={{ fontSize: isMobile ? 18 : 20, fontWeight: 800, lineHeight: 1.25 }}>{youtubeImport.title}</div>
                       </div>
                     </div>
                     <div

--- a/frontend/components/AuthRouteGuard.tsx
+++ b/frontend/components/AuthRouteGuard.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, type ReactNode } from "react";
+
+import { useAuth } from "@/context/AuthContext";
+
+const protectedPrefixes = [
+  "/analytics",
+  "/clips",
+  "/dashboard",
+  "/podcasts",
+  "/profile",
+  "/settings",
+  "/upload",
+];
+
+function isProtectedPath(pathname: string): boolean {
+  return protectedPrefixes.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function AuthRouteGuard({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { backendToken, loading, user } = useAuth();
+  const protectedPath = isProtectedPath(pathname);
+  const authenticated = Boolean(user || backendToken);
+
+  useEffect(() => {
+    if (!protectedPath || loading || authenticated) {
+      return;
+    }
+
+    const queryString = window.location.search;
+    const nextPath = queryString ? `${pathname}${queryString}` : pathname;
+    router.replace(`/login?next=${encodeURIComponent(nextPath)}`);
+  }, [authenticated, loading, pathname, protectedPath, router]);
+
+  if (protectedPath && (loading || !authenticated)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#0d1008] text-[#a3d06b]">
+        <div className="h-10 w-10 animate-spin rounded-full border-2 border-[#2b3d1e] border-t-[#a3d06b]" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/components/AuthScaffold.tsx
+++ b/frontend/components/AuthScaffold.tsx
@@ -89,7 +89,7 @@ export function AuthScaffold({
         />
 
         <div style={{ position: "relative", zIndex: 1, maxWidth: 620, margin: "0 auto" }}>
-          <BrandMark accent={shell.accent} inverse />
+          <BrandMark accent={shell.accent} inverse={dark} />
 
           <div
             className="ic-premium-card"

--- a/frontend/components/PodcastCard.tsx
+++ b/frontend/components/PodcastCard.tsx
@@ -641,7 +641,7 @@ export function PodcastCard({
                   </span>
 
                   <Link
-                    href={`/clips?podcastId=${podcast.id}`}
+                    href={hasGeneratedVideos ? `/clips/generated?podcastId=${podcast.id}` : `/clips?podcastId=${podcast.id}`}
                     style={{
                       display: "inline-flex",
                       alignItems: "center",
@@ -658,7 +658,7 @@ export function PodcastCard({
                       flexShrink: 0,
                     }}
                   >
-                    Open clips <ChevronRight size={10} />
+                    {hasGeneratedVideos ? "Open clips" : "Generate clips"} <ChevronRight size={10} />
                   </Link>
                 </div>
               </div>

--- a/frontend/components/UserProfileCard.tsx
+++ b/frontend/components/UserProfileCard.tsx
@@ -19,10 +19,15 @@ function formatMemberDate(value: string | null): string {
     return "Recently joined";
   }
 
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Recently joined";
+  }
+
   return new Intl.DateTimeFormat("en", {
     month: "short",
     year: "numeric",
-  }).format(new Date(value));
+  }).format(date);
 }
 
 function formatSubtitlePreset(preset?: string | null): string {


### PR DESCRIPTION
## Summary
This PR completes my frontend/UI review work for the InsightClips flow after the backend/storage updates were merged.

## What I worked on
- Added protected route handling so logged-out users are redirected away from private pages.
- Improved login redirect behavior so users can return to the page they originally tried to open.
- Improved fallback states for pages that can load without uploads, clips, or profile data.
- Fixed the profile date formatting fallback so invalid/missing dates do not break the UI.
- Improved the demo page fallback behavior when the demo video is not available.
- Improved logo visibility on auth/register screens.
- Polished dashboard UI and removed the extra upload button near YouTube to keep the header cleaner.
- Improved profile delete-account styling so it matches the app palette better and does not look aggressively red.
- Improved Upload and YouTube import UI copy, spacing, and states so both flows feel more consistent.
- Split the Clips workflow into clearer pages:
  - `/clips` for clip generation setup/options.
  - `/clips/generated` for generated videos, search, publishing, download, and planning.
  - `/clips/generate` remains available as a generation route.
- Updated navigation links from dashboard, upload, analytics, and podcast cards so users land on the correct Clips page.
- Improved generated clip cards so the page is less crowded.
- Added expandable planning cards for TikTok, LinkedIn, and YouTube suggestions.
- Added working copy actions for:
  - full post text
  - captions
  - hashtags
- Added clipboard fallback support for browsers where `navigator.clipboard` is unavailable.
- Improved shared styling in `globals.css` for cleaner cards, focus states, and expandable sections.

## Pages/areas reviewed
- Dashboard
- Upload
- YouTube import
- Clips generation
- Generated clips/results
- Analytics links into clips
- Profile
- Login/protected routes
- Demo page
- Podcast cards
- Auth/register visual layout

## Testing
- Ran frontend lint successfully.
- Ran frontend tests successfully.
- Ran frontend production build successfully.

## Commands run
```bash
npm run lint
npm run test
npm run build