### PR TITLE
Feature/penark clips work

### DIFF
--- a/backend/app/models/clipping.py
+++ b/backend/app/models/clipping.py
@@ -82,7 +82,7 @@ class GenerateClipsRequest(BaseModel):
     generation_settings: GenerationSettingsInput | None = None
     clip_duration_seconds: int | None = Field(default=None, ge=8, le=90)
     number_of_clips: int | None = Field(default=None, ge=1, le=10)
-    topic_focus: str | None = Field(default=None, max_length=120)
+    topic_focus: str | None = Field(default=None, max_length=500)
     subtitles_enabled: bool | None = None
     visual_output_mode: VisualOutputMode = "original_people"
     save_generation_settings: bool = False

--- a/backend/app/models/export_settings.py
+++ b/backend/app/models/export_settings.py
@@ -162,7 +162,7 @@ class GenerationSettings(BaseModel):
 
     clip_duration_seconds: int = Field(default=30, ge=8, le=90)
     number_of_clips: int = Field(default=5, ge=1, le=10)
-    topic_focus: str | None = Field(default=None, max_length=120)
+    topic_focus: str | None = Field(default=None, max_length=500)
     subtitles_enabled: bool = True
 
     @field_validator("topic_focus")
@@ -183,7 +183,7 @@ class GenerationSettingsInput(BaseModel):
 
     clip_duration_seconds: int | None = Field(default=None, ge=8, le=90)
     number_of_clips: int | None = Field(default=None, ge=1, le=10)
-    topic_focus: str | None = Field(default=None, max_length=120)
+    topic_focus: str | None = Field(default=None, max_length=500)
     subtitles_enabled: bool | None = None
 
     @field_validator("topic_focus")

--- a/backend/app/services/clipping_service.py
+++ b/backend/app/services/clipping_service.py
@@ -562,7 +562,34 @@ def _select_segments(
             item.segment_start_seconds,
         ),
     )
-    return sorted_segments[:min(settings.number_of_clips, MAX_GENERATED_CLIPS)]
+    target_count = min(settings.number_of_clips, MAX_GENERATED_CLIPS)
+    selected: list[ScoreSegment] = []
+
+    for segment in sorted_segments:
+        if all(not _segments_substantially_overlap(segment, existing) for existing in selected):
+            selected.append(segment)
+        if len(selected) >= target_count:
+            return selected
+
+    for segment in sorted_segments:
+        if segment not in selected:
+            selected.append(segment)
+        if len(selected) >= target_count:
+            break
+
+    return selected
+
+
+def _segments_substantially_overlap(left: ScoreSegment, right: ScoreSegment) -> bool:
+    overlap_start = max(left.segment_start_seconds, right.segment_start_seconds)
+    overlap_end = min(left.segment_end_seconds, right.segment_end_seconds)
+    overlap = max(0.0, overlap_end - overlap_start)
+    if overlap <= 0:
+        return False
+
+    left_duration = max(0.1, left.segment_end_seconds - left.segment_start_seconds)
+    right_duration = max(0.1, right.segment_end_seconds - right.segment_start_seconds)
+    return overlap / min(left_duration, right_duration) >= 0.55
 
 
 def _score_segment_for_generation(segment: ScoreSegment, topic_focus: str | None) -> float:
@@ -615,11 +642,17 @@ def _resolve_clip_window(
             end,
             max_duration=transcription.duration_seconds,
         )
-        return _apply_requested_duration(
+        adjusted_start, adjusted_end = _apply_requested_duration(
             expanded_start,
             expanded_end,
             max_duration=transcription.duration_seconds,
             target_duration_seconds=target_duration_seconds,
+        )
+        return _snap_clip_window_to_words(
+            adjusted_start,
+            adjusted_end,
+            transcription.words,
+            max_duration=transcription.duration_seconds,
         )
 
     expanded_start, expanded_end = _expand_clip_window(
@@ -633,11 +666,17 @@ def _resolve_clip_window(
         clip_end_seconds=expanded_end,
     ):
         return expanded_start, expanded_end
-    return _apply_requested_duration(
+    adjusted_start, adjusted_end = _apply_requested_duration(
         expanded_start,
         expanded_end,
         max_duration=transcription.duration_seconds,
         target_duration_seconds=target_duration_seconds,
+    )
+    return _snap_clip_window_to_words(
+        adjusted_start,
+        adjusted_end,
+        transcription.words,
+        max_duration=transcription.duration_seconds,
     )
 
 
@@ -663,6 +702,36 @@ def _apply_requested_duration(
     if adjusted_end - adjusted_start < min(target_duration, max_duration):
         adjusted_start = max(0.0, adjusted_end - target_duration)
     return round(adjusted_start, 3), round(adjusted_end, 3)
+
+
+def _snap_clip_window_to_words(
+    start_seconds: float,
+    end_seconds: float,
+    words: list[TranscriptWord],
+    *,
+    max_duration: float,
+) -> tuple[float, float]:
+    if not words:
+        return round(start_seconds, 3), round(end_seconds, 3)
+
+    sorted_words = sorted(words, key=lambda item: (item.start, item.end))
+    snapped_start = start_seconds
+    snapped_end = end_seconds
+
+    for word in sorted_words:
+        if word.start <= start_seconds < word.end:
+            snapped_start = max(0.0, word.start)
+            break
+
+    for word in sorted_words:
+        if word.start < end_seconds <= word.end:
+            snapped_end = min(max_duration, word.end)
+            break
+
+    if snapped_end <= snapped_start:
+        return round(start_seconds, 3), round(end_seconds, 3)
+
+    return round(snapped_start, 3), round(snapped_end, 3)
 
 
 def _match_segment_snippet_window(

--- a/backend/app/services/media_service.py
+++ b/backend/app/services/media_service.py
@@ -331,21 +331,16 @@ def _tune_subtitle_style(
     if tuned.preset != "minimal" and tuned.outline_color == tuned.primary_color:
         tuned.outline_color = "#000000" if tuned.primary_color.upper() != "#000000" else "#FFFFFF"
 
-    if export_mode == "portrait" and tuned.position == "bottom" and duration >= 45:
-        tuned.position = "center"
-
     if visual_output_mode == "book_like":
         if tuned.font_family == "Arial":
             tuned.font_family = "Georgia"
         tuned.italic = True
-        tuned.position = "top"
         tuned.background_opacity = max(tuned.background_opacity, 0.42)
         tuned.font_size = max(tuned.font_size, 20 if export_mode == "landscape" else 22)
     elif visual_output_mode == "stylized_animated":
         if tuned.font_family == "Arial":
             tuned.font_family = "DM Sans"
         tuned.bold = True
-        tuned.position = "center"
         tuned.background_opacity = max(tuned.background_opacity, 0.58)
         tuned.font_size = max(tuned.font_size, 24 if export_mode == "portrait" else 20)
 

--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -343,7 +343,7 @@ function AnalyticsPageContent() {
                 Track clip performance and ranking by podcast.
               </h1>
               <p style={{ fontSize: 15, lineHeight: 1.8, color: t.textSub, maxWidth: 700 }}>
-                This analytics board shows the selected podcast&apos;s views, downloads, click trend, and top clip performance so publishing decisions stay visible.
+                This analytics board shows the selected podcast&apos;s downloads, click trend, and top clip performance so publishing decisions stay visible.
               </p>
             </div>
 
@@ -360,7 +360,7 @@ function AnalyticsPageContent() {
             >
               {[
                 { label: "Podcasts", value: podcasts.length, sub: "available in analytics" },
-                { label: "Top Views", value: topClip?.views ?? 0, sub: "best clip reach" },
+                { label: "Top Downloads", value: topClip?.downloads ?? 0, sub: "best clip reach" },
                 { label: "Downloads", value: metrics?.total_downloads ?? 0, sub: "selected podcast total" },
                 { label: "Trend", value: formatAnalyticsChange(metrics?.average_click_trend ?? 0), sub: "average click change" },
               ].map((item) => (
@@ -523,7 +523,7 @@ function AnalyticsPageContent() {
                   </h2>
                   <p style={{ marginTop: 8, color: t.textSub }}>
                     {metrics
-                      ? `${metrics.total_clips} total clips / ${metrics.published_clips} published / ${metrics.total_views} views`
+                    ? `${metrics.total_clips} total clips / ${metrics.published_clips} published / ${metrics.total_downloads} downloads`
                       : "Select a podcast and load metrics to begin."}
                   </p>
                 </div>

--- a/frontend/app/clips/page.tsx
+++ b/frontend/app/clips/page.tsx
@@ -49,7 +49,6 @@ import {
   type VisualOutputMode,
 } from "@/lib/api";
 import {
-  applyGenerationTemplate,
   buildGenerationRequestPayload,
   buildDefaultGenerationSettings,
   describeGenerationSettings,
@@ -327,7 +326,7 @@ function formatGenerationFailureMessage(error: unknown): string {
   const normalized = baseMessage.toLowerCase();
 
   if (normalized.includes("topic_focus")) {
-    return "Topic focus only supports letters, numbers, spaces, and simple punctuation.";
+    return "Generation settings only support letters, numbers, spaces, and simple punctuation.";
   }
   if (normalized.includes("ffmpeg")) {
     return `${baseMessage} Try Quick setup first with fewer clips, 15s or 30s length, and Original People mode.`;
@@ -389,6 +388,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
     useState<ExportSettings | null>(null);
   const [visualOutputMode, setVisualOutputMode] =
     useState<VisualOutputMode>("original_people");
+  const [generationStartedAt, setGenerationStartedAt] = useState<number | null>(null);
 
   const t = dark ? T.dark : T.light;
   const isMobile = viewportWidth < 960;
@@ -437,7 +437,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
     [generationSettings],
   );
   const hasCompleteClipSet = clips.length >= generationSettings.number_of_clips;
-  const topicFocusSummary = generationSettings.topic_focus.trim();
+  const projectPromptSummary = generationSettings.topic_focus.trim();
   const selectedVisualModeSummary =
     VISUAL_OUTPUT_MODES.find((mode) => mode.value === visualOutputMode) ?? VISUAL_OUTPUT_MODES[0];
 
@@ -608,12 +608,20 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
     }
 
     let cancelled = false;
+    const startedAt = generationStartedAt ?? Date.now();
+    const generationTimeoutMs = 8 * 60 * 1000;
 
     const refreshGeneratedClips = async () => {
       try {
         const token = backendToken ?? (await syncBackendSession());
         if (!token || cancelled) {
           return;
+        }
+
+        if (Date.now() - startedAt > generationTimeoutMs) {
+          throw new Error(
+            "Clip generation timed out after 8 minutes. The backend may be stuck on rendering or waiting on storage.",
+          );
         }
 
         const result = await getClips(selectedPodcastId, token);
@@ -627,7 +635,18 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
         }
         setWorkspaceView("results");
       } catch {
-        // The main generation request still owns the final error message.
+        if (!cancelled && Date.now() - startedAt > generationTimeoutMs) {
+          setGenerating(false);
+          setGenerationStartedAt(null);
+          setError(
+            "Clip generation timed out after 8 minutes. Try fewer clips, a shorter duration, or rerun generation.",
+          );
+          setActionFeedback({
+            tone: "error",
+            message:
+              "Clip generation timed out after 8 minutes. Try fewer clips, a shorter duration, or rerun generation.",
+          });
+        }
       }
     };
 
@@ -643,6 +662,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
   }, [
     authLoading,
     backendToken,
+    generationStartedAt,
     generating,
     selectedPodcast,
     selectedPodcastId,
@@ -768,13 +788,6 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
     );
   };
 
-  const handleGenerationTemplateChange = (templateId: GenerationTemplateId) => {
-    const next = applyGenerationTemplate(templateId, generationExportSettings);
-    setGenerationTemplateId(templateId);
-    setGenerationSettings(next.generationSettings);
-    setGenerationExportSettings(next.exportSettings);
-  };
-
   const handleVisualOutputModeChange = (mode: VisualOutputMode) => {
     setVisualOutputMode(mode);
     if (mode === "stylized_animated") {
@@ -839,6 +852,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
     }
 
     setGenerating(true);
+    setGenerationStartedAt(Date.now());
     setError("");
     setActionFeedback({
       tone: "info",
@@ -915,6 +929,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
       });
     } finally {
       setGenerating(false);
+      setGenerationStartedAt(null);
     }
   };
 
@@ -1738,9 +1753,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
                 <>
                   <GenerationSettingsPanel
                     dark={dark}
-                    templateId={generationTemplateId}
                     settings={generationSettings}
-                    onTemplateChange={handleGenerationTemplateChange}
                     onSettingsChange={handleGenerationSettingsChange}
                     storageHint="These preferences are reused across the upload and clips workflow on this device."
                     palette={{
@@ -2049,81 +2062,30 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
                 <div
                   style={{
                     display: "grid",
-                    gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 200px), 1fr))",
-                    gap: 10,
-                    alignItems: "stretch",
+                    gap: 8,
                     marginBottom: 16,
+                    fontSize: 13,
+                    lineHeight: 1.7,
+                    color: t.textSub,
                   }}
                 >
-                  {[
-                    {
-                      label: "Generation setup",
-                      value: generationSummary,
-                      detail: "Shared with the upload flow so your clip defaults stay consistent.",
-                    },
-                    {
-                      label: "Topic focus",
-                      value: topicFocusSummary || "No topic focus yet",
-                      detail: topicFocusSummary
-                        ? "This guidance shapes what moments the generator should prioritize."
-                        : "Add topic focus above if you want planning suggestions to follow a clearer angle.",
-                    },
-                    {
-                      label: "Hashtag pool",
-                      value:
-                        planningHashtagPreview.length > 0
-                          ? planningHashtagPreview.join(" ")
-                          : "Waiting for hashtags",
-                      detail:
-                        planningHashtagPreview.length > 0
-                          ? "Shared tags collected from the current planning suggestions."
-                          : "Hashtags appear here once the content calendar has enough clip data.",
-                    },
-                    {
-                      label: "Visual mode",
-                      value: selectedVisualModeSummary.label,
-                      detail: selectedVisualModeSummary.title,
-                    },
-                  ].map((item) => (
-                    <div
-                      key={item.label}
-                      style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        borderRadius: 16,
-                        border: `1px solid ${t.borderSub}`,
-                        background: t.cardAlt,
-                        padding: "14px 15px",
-                        minHeight: 168,
-                      }}
-                    >
-                      <div
-                        style={{
-                          fontSize: 10,
-                          letterSpacing: ".18em",
-                          textTransform: "uppercase",
-                          color: t.textFaint,
-                          marginBottom: 6,
-                        }}
-                      >
-                        {item.label}
-                      </div>
-                      <div
-                        style={{
-                          fontSize: 14,
-                          fontWeight: 700,
-                          color: t.text,
-                          lineHeight: 1.5,
-                          marginBottom: 6,
-                        }}
-                      >
-                        {item.value}
-                      </div>
-                      <div style={{ fontSize: 12, color: t.textSub, lineHeight: 1.6, marginTop: "auto" }}>
-                        {item.detail}
-                      </div>
-                    </div>
-                  ))}
+                  <div style={{ overflowWrap: "anywhere" }}>
+                    <strong style={{ color: t.text }}>Generation setup:</strong> {generationSummary}.
+                  </div>
+                  <div style={{ overflowWrap: "anywhere" }}>
+                    <strong style={{ color: t.text }}>Video topic:</strong>{" "}
+                    {projectPromptSummary || "Not set yet."}
+                  </div>
+                  <div style={{ overflowWrap: "anywhere" }}>
+                    <strong style={{ color: t.text }}>Hashtags:</strong>{" "}
+                    {planningHashtagPreview.length > 0
+                      ? planningHashtagPreview.join(" ")
+                      : "Waiting for hashtags."}
+                  </div>
+                  <div style={{ overflowWrap: "anywhere" }}>
+                    <strong style={{ color: t.text }}>Visual mode:</strong>{" "}
+                    {selectedVisualModeSummary.label} - {selectedVisualModeSummary.title}.
+                  </div>
                 </div>
 
                 {loadingCalendar ? (
@@ -2471,7 +2433,7 @@ export function ClipsPageContent({ mode = "results" }: ClipsPageContentProps = {
                     {generating
                       ? "The backend is creating the MP4 files now. The first ready clips will appear here automatically when rendering finishes."
                       : clips.length === 0
-                        ? "Generate clips for this podcast to unlock discovery, recommendations, and publish actions. Use the settings above to choose the template, clip length, topic focus, and subtitle behavior first."
+                        ? "Generate clips for this podcast to unlock discovery, recommendations, and publish actions. Use the settings above to choose the template, clip length, visual format, and subtitle behavior first."
                       : "Try another search or filter to surface different clip candidates."}
                   </p>
                   {clips.length > 0 && activeSearch ? (

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -592,9 +592,19 @@ export default function DashboardPage() {
 
           {/* Nav */}
           <nav style={{ flex: 1, padding: "14px 10px", display: "flex", flexDirection:"column", gap: 4 }}>
+            {!collapsed && (
+              <div style={{ padding: "6px 10px 8px", fontSize: 10, fontWeight: 700, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint }}>
+                Workspace
+              </div>
+            )}
             <NavItem icon={LayoutDashboard} label="Overview"  href="/dashboard" active t={t} collapsed={collapsed}/>
             <NavItem icon={Library}         label="Library"   href="/podcasts"  t={t} collapsed={collapsed}/>
             <NavItem icon={BarChart2}       label="Analytics" href="/analytics" t={t} collapsed={collapsed}/>
+            {!collapsed && (
+              <div style={{ padding: "14px 10px 8px", fontSize: 10, fontWeight: 700, letterSpacing: ".2em", textTransform: "uppercase", color: t.textFaint }}>
+                Account
+              </div>
+            )}
             <NavItem icon={User}             label="Profile"   href="/profile"   t={t} collapsed={collapsed}/>
             <NavItem icon={Settings}         label="Settings"  href="/settings"  t={t} collapsed={collapsed}/>
             <NavItem icon={CreditCard}       label="Billing"   href="/settings/billing"  t={t} collapsed={collapsed}/>

--- a/frontend/app/podcasts/page.tsx
+++ b/frontend/app/podcasts/page.tsx
@@ -408,10 +408,10 @@ export default function PodcastsPage() {
           {[
             {
               icon: Radio,
-              title: "Workspace rhythm",
+              title: "Processing status",
               text: processingCount
                 ? `${processingCount} episode${processingCount > 1 ? "s are" : " is"} actively processing right now.`
-                : "Everything is calm right now with no pending processing queue.",
+                : "No episodes are waiting to be processed right now.",
             },
             {
               icon: Sparkles,

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -201,10 +201,10 @@ export default function ProfilePage() {
       errorBg: base.errorBg,
       errorBorder: base.errorBd,
       errorText: base.errorText,
-      deleteBg: dark ? "rgba(90,158,58,.1)" : "rgba(241,249,235,.92)",
-      deleteBorder: dark ? "rgba(130,205,110,.26)" : "rgba(130,205,110,.38)",
-      deleteText: dark ? "#bfe4ab" : "#3f7f25",
-      deleteButton: dark ? "#3c7627" : "#5a9e3a",
+      deleteBg: dark ? "rgba(95,18,18,.9)" : "rgba(255,236,236,.96)",
+      deleteBorder: dark ? "rgba(234,88,88,.35)" : "rgba(214,67,67,.35)",
+      deleteText: dark ? "#ffb4b4" : "#b42318",
+      deleteButton: dark ? "#d64545" : "#c92a2a",
     };
   }, [dark]);
 

--- a/frontend/app/settings/export/page.tsx
+++ b/frontend/app/settings/export/page.tsx
@@ -763,7 +763,7 @@ export default function ExportSettingsPage() {
                     This page saves your default export profile.
                   </div>
                   <p style={{ margin: 0, fontSize: 13, lineHeight: 1.72, color: palette.muted, maxWidth: 680 }}>
-                    Keep only the defaults here for future uploads. Clip-specific creative work like generation flow, prompt focus, and final polishing belongs in the Clips page.
+                    Keep only the defaults here for future uploads. Clip-specific creative work like generation flow, output format, and final polishing belongs in the Clips page.
                   </p>
                 </div>
                 <button

--- a/frontend/app/upload/UploadWorkspace.tsx
+++ b/frontend/app/upload/UploadWorkspace.tsx
@@ -1488,7 +1488,7 @@ export default function UploadWorkspace({
                   <div style={{ display: "grid", gap: 10 }}>
                     {[
                       "Choose the source, target platform, and framing here.",
-                      "Open Clips after analysis to tune prompt, subtitles, timing, and final visual feel.",
+                      "Open Clips after analysis to tune format, subtitles, timing, and final visual feel.",
                       "This keeps the first step fast for every age and every device.",
                     ].map((step) => (
                       <div
@@ -1581,9 +1581,7 @@ export default function UploadWorkspace({
                   {
                     label: "Clip setup",
                     value: generationSummary,
-                    detail: generationSettings.topic_focus.trim()
-                      ? generationSettings.topic_focus
-                      : "No extra topic focus yet. You can add it in Clips.",
+                    detail: "Clip count, duration, and subtitles are ready for Clips.",
                   },
                   {
                     label: "Subtitle starter",
@@ -1790,9 +1788,7 @@ export default function UploadWorkspace({
                       {
                         label: "Clip generation",
                         value: generationSummary,
-                        detail: generationSettings.topic_focus.trim()
-                          ? generationSettings.topic_focus
-                          : "No extra topic focus yet. These defaults carry into the clips page.",
+                        detail: "Clip count, duration, and subtitles carry into the clips page.",
                       },
                       {
                         label: "Audio leveling",

--- a/frontend/components/AuthScaffold.tsx
+++ b/frontend/components/AuthScaffold.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useEffect } from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
@@ -50,21 +51,37 @@ export function AuthScaffold({
   children,
   footerLabel,
 }: AuthScaffoldProps) {
+  useEffect(() => {
+    const previousBodyOverflow = document.body.style.overflow;
+    const previousHtmlOverflow = document.documentElement.style.overflow;
+
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousBodyOverflow;
+      document.documentElement.style.overflow = previousHtmlOverflow;
+    };
+  }, []);
+
   return (
     <div
       className="auth-stage"
       style={{
-        minHeight: "100vh",
+        height: "100vh",
         background: shell.bg,
         color: shell.text,
         fontFamily: "var(--font-sans)",
+        overflow: "hidden",
       }}
     >
       <section
         className="auth-showcase ic-premium-card"
         style={{
+          height: "100%",
           background: shell.showcase,
           borderRight: `1px solid ${shell.border}`,
+          overflow: "hidden",
         }}
       >
         <div
@@ -169,7 +186,9 @@ export function AuthScaffold({
       <section
         className="auth-panel"
         style={{
+          height: "100%",
           background: dark ? "rgba(13,16,8,.94)" : "rgba(245,248,238,.96)",
+          overflow: "hidden",
         }}
       >
         <div
@@ -179,6 +198,7 @@ export function AuthScaffold({
             display: "flex",
             flexDirection: "column",
             minHeight: "100%",
+            overflow: "hidden",
           }}
         >
           <div

--- a/frontend/components/GenerationSettingsPanel.tsx
+++ b/frontend/components/GenerationSettingsPanel.tsx
@@ -1,16 +1,13 @@
-import type { GenerationSettings, GenerationTemplateId } from "@/lib/api";
+import type { GenerationSettings } from "@/lib/api";
 import {
   CLIP_COUNT_OPTIONS,
   CLIP_DURATION_OPTIONS,
-  GENERATION_TEMPLATES,
-  MAX_TOPIC_FOCUS_LENGTH,
+  MAX_TOPIC_LENGTH,
 } from "@/lib/generation-settings";
 
 type GenerationSettingsPanelProps = {
   dark: boolean;
-  templateId: GenerationTemplateId;
   settings: GenerationSettings;
-  onTemplateChange: (templateId: GenerationTemplateId) => void;
   onSettingsChange: (changes: Partial<GenerationSettings>) => void;
   palette: {
     border: string;
@@ -26,13 +23,11 @@ type GenerationSettingsPanelProps = {
 
 export default function GenerationSettingsPanel({
   dark,
-  templateId,
   settings,
-  onTemplateChange,
   onSettingsChange,
   palette,
   title = "Plan the clips before generation starts",
-  description = "Choose a template, set clip length and count, decide whether subtitles stay on, and guide the model with a focused prompt.",
+  description = "Use Topic to guide clip selection from this video. Keep fixed output settings in the controls below.",
   storageHint = null,
 }: GenerationSettingsPanelProps) {
   return (
@@ -161,162 +156,6 @@ export default function GenerationSettingsPanel({
           ) : null}
         </div>
 
-        <div
-          style={{
-            borderRadius: 18,
-            border: `1px solid ${palette.subBorder}`,
-            background: dark ? "rgba(11,18,9,.92)" : "rgba(247,252,243,.96)",
-            padding: "14px 14px 13px",
-          }}
-        >
-          <div
-            style={{
-              fontSize: 10,
-              letterSpacing: ".2em",
-              textTransform: "uppercase",
-              color: palette.hi2,
-              fontWeight: 700,
-              marginBottom: 10,
-            }}
-          >
-            Current focus
-          </div>
-          <div
-            style={{
-              fontSize: 14,
-              fontWeight: 700,
-              color: dark ? "#dff0d8" : "#1e3418",
-              marginBottom: 6,
-            }}
-          >
-            {settings.topic_focus.trim() || "No extra topic guidance yet"}
-          </div>
-          <div style={{ fontSize: 12, color: palette.muted, lineHeight: 1.65 }}>
-            Add a short instruction if you want the generator to prioritize a theme, angle, or type
-            of moment.
-          </div>
-        </div>
-      </div>
-
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit,minmax(min(100%,180px),1fr))",
-          gap: 10,
-          marginTop: 18,
-          marginBottom: 18,
-        }}
-      >
-        {GENERATION_TEMPLATES.map((template) => {
-          const active = template.id === templateId;
-
-          return (
-            <button
-              key={template.id}
-              type="button"
-              onClick={() => onTemplateChange(template.id)}
-              style={{
-                textAlign: "left",
-                borderRadius: 18,
-                padding: "15px 15px 14px",
-                border: `1px solid ${active ? palette.hi : palette.subBorder}`,
-                background: active
-                  ? dark
-                    ? "rgba(90,158,58,.16)"
-                    : "rgba(90,158,58,.1)"
-                  : dark
-                    ? "rgba(11,18,9,.55)"
-                    : "rgba(248,252,245,.82)",
-                color: dark ? "#e8f5df" : "#152412",
-                cursor: "pointer",
-              }}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: 10,
-                  marginBottom: 10,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: 10,
-                    fontWeight: 700,
-                    letterSpacing: ".16em",
-                    textTransform: "uppercase",
-                    color: active ? "#dff0d8" : palette.hi2,
-                  }}
-                >
-                  {template.label}
-                </div>
-                <div
-                  style={{
-                    borderRadius: 999,
-                    padding: "4px 8px",
-                    border: `1px solid ${active ? "rgba(255,255,255,.22)" : palette.subBorder}`,
-                    fontSize: 9,
-                    fontWeight: 700,
-                    letterSpacing: ".14em",
-                    textTransform: "uppercase",
-                    color: active ? "#dff0d8" : palette.hi2,
-                  }}
-                >
-                  {template.badge}
-                </div>
-              </div>
-              <div
-                style={{
-                  fontSize: 13,
-                  fontWeight: 700,
-                  color: active ? (dark ? "#dff0d8" : "#285019") : palette.hi2,
-                  marginBottom: 6,
-                }}
-              >
-                {template.title}
-              </div>
-              <div
-                style={{
-                  fontSize: 12,
-                  lineHeight: 1.6,
-                  color: active
-                    ? dark
-                      ? "rgba(232,245,223,.82)"
-                      : "rgba(21,36,18,.8)"
-                    : palette.muted,
-                  marginBottom: 10,
-                }}
-              >
-                {template.description}
-              </div>
-              <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                <span
-                  style={{
-                    borderRadius: 999,
-                    border: `1px solid ${active ? "rgba(255,255,255,.18)" : palette.subBorder}`,
-                    padding: "4px 8px",
-                    fontSize: 10,
-                    color: active ? "#dff0d8" : palette.muted,
-                  }}
-                >
-                  {template.generationSettings.clip_duration_seconds}s
-                </span>
-                <span
-                  style={{
-                    borderRadius: 999,
-                    border: `1px solid ${active ? "rgba(255,255,255,.18)" : palette.subBorder}`,
-                    padding: "4px 8px",
-                    fontSize: 10,
-                    color: active ? "#dff0d8" : palette.muted,
-                  }}
-                >
-                  {template.generationSettings.number_of_clips} clips
-                </span>
-              </div>
-            </button>
-          );
-        })}
       </div>
 
       <div
@@ -543,23 +382,23 @@ export default function GenerationSettingsPanel({
               fontWeight: 700,
             }}
           >
-            Topic focus
+            Topic
           </div>
           <div style={{ fontSize: 11, color: palette.muted }}>
-            {settings.topic_focus.trim().length}/{MAX_TOPIC_FOCUS_LENGTH}
+            {settings.topic_focus.trim().length}/{MAX_TOPIC_LENGTH}
           </div>
         </div>
         <textarea
           value={settings.topic_focus}
           onChange={(event) =>
             onSettingsChange({
-              topic_focus: event.target.value.slice(0, MAX_TOPIC_FOCUS_LENGTH),
+              topic_focus: event.target.value.slice(0, MAX_TOPIC_LENGTH),
             })
           }
           onKeyDownCapture={(event) => {
             event.stopPropagation();
           }}
-          placeholder="Example: Prioritize moments about audience growth, retention, or clear tactical advice."
+          placeholder="Example: audience growth, strong hooks, expert takeaways, or the most interesting moments from this video."
           rows={3}
           spellCheck={false}
           style={{
@@ -576,7 +415,12 @@ export default function GenerationSettingsPanel({
             outline: "none",
           }}
         />
+        <div style={{ marginTop: 8, fontSize: 12, color: palette.muted, lineHeight: 1.6 }}>
+          Use this to tell InsightClips what to look for inside this video. Put the theme, hook style,
+          story angle, or exact moments you want surfaced.
+        </div>
       </label>
+
     </section>
   );
 }

--- a/frontend/lib/analytics-presentation.tsx
+++ b/frontend/lib/analytics-presentation.tsx
@@ -37,24 +37,24 @@ export function buildAnalyticsSnapshot(metrics: PodcastClipMetrics | null): {
   topClip: PodcastClipMetrics["top_clips"][number] | null;
   totalVisibility: number;
   publishRate: number;
-  averageViewsPerClip: number;
+  averageDownloadsPerClip: number;
 } {
   const topClip = metrics?.top_clips[0] ?? null;
-  const totalVisibility = metrics ? metrics.total_views + metrics.total_downloads : 0;
+  const totalVisibility = metrics ? metrics.total_downloads : 0;
   const publishRate =
     metrics && metrics.total_clips > 0
       ? Math.round((metrics.published_clips / metrics.total_clips) * 100)
       : 0;
-  const averageViewsPerClip =
+  const averageDownloadsPerClip =
     metrics && metrics.total_clips > 0
-      ? Math.round(metrics.total_views / metrics.total_clips)
+      ? Math.round(metrics.total_downloads / metrics.total_clips)
       : 0;
 
   return {
     topClip,
     totalVisibility,
     publishRate,
-    averageViewsPerClip,
+    averageDownloadsPerClip,
   };
 }
 
@@ -74,7 +74,6 @@ export function AnalyticsMetricsDisplay({
   const snapshot = buildAnalyticsSnapshot(metrics);
   const metricCards = metrics
     ? [
-        { label: "Views", value: metrics.total_views },
         { label: "Downloads", value: metrics.total_downloads },
         { label: "Published", value: metrics.published_clips },
         {
@@ -166,9 +165,9 @@ export function AnalyticsMetricsDisplay({
           <div style={{ fontSize: 34, lineHeight: 1.04, marginBottom: 8 }}>
             {snapshot.totalVisibility}
           </div>
-          <div style={{ color: theme.textSub, lineHeight: 1.75 }}>
-            Combined views and downloads across the selected podcast&apos;s clip set,
-            averaging {snapshot.averageViewsPerClip} views per clip.
+        <div style={{ color: theme.textSub, lineHeight: 1.75 }}>
+            Combined downloads across the selected podcast&apos;s clip set,
+            averaging {snapshot.averageDownloadsPerClip} downloads per clip.
           </div>
         </MetricPanel>
 
@@ -185,13 +184,13 @@ export function AnalyticsMetricsDisplay({
                 <MetricBadge
                   background={theme.chip}
                   color={theme.accent}
-                  label={`${snapshot.topClip.views} views`}
+                  label={`${snapshot.topClip.downloads} downloads`}
                 />
                 <MetricBadge
                   background={theme.cardAlt}
                   border={`1px solid ${theme.borderSub}`}
                   color={theme.textSub}
-                  label={`${snapshot.topClip.downloads} downloads`}
+                  label={snapshot.topClip.published ? "Published" : "Private"}
                 />
                 <MetricBadge
                   background={theme.cardAlt}
@@ -247,7 +246,7 @@ export function AnalyticsMetricsDisplay({
               Top Clips Table
             </div>
             <h3 style={{ margin: 0, fontSize: 30, lineHeight: 1.05 }}>
-              Views, downloads, and click trends
+              Downloads and click trends
             </h3>
           </div>
           {metrics.estimated ? (
@@ -305,9 +304,8 @@ export function AnalyticsMetricsDisplay({
                     {clip.published ? "Published" : "Private"}
                   </span>
                 </div>
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(3,minmax(0,1fr))", gap: 8, marginTop: 12 }}>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(2,minmax(0,1fr))", gap: 8, marginTop: 12 }}>
                   {[
-                    { label: "Views", value: clip.views },
                     { label: "Downloads", value: clip.downloads },
                     { label: "Trend", value: formatAnalyticsChange(clip.click_trend), tone: clip.click_trend >= 0 ? theme.accent : theme.errorText },
                   ].map((item) => (
@@ -338,7 +336,6 @@ export function AnalyticsMetricsDisplay({
                   }}
                 >
                   <th style={{ padding: "0 0 12px" }}>Clip</th>
-                  <th style={{ padding: "0 0 12px" }}>Views</th>
                   <th style={{ padding: "0 0 12px" }}>Downloads</th>
                   <th style={{ padding: "0 0 12px" }}>Click Trend</th>
                   <th style={{ padding: "0 0 12px" }}>Status</th>
@@ -362,10 +359,7 @@ export function AnalyticsMetricsDisplay({
                         {clip.title}
                       </div>
                     </td>
-                    <td style={{ padding: "14px 0", fontWeight: 700 }}>{clip.views}</td>
-                    <td style={{ padding: "14px 0", fontWeight: 700 }}>
-                      {clip.downloads}
-                    </td>
+                    <td style={{ padding: "14px 0", fontWeight: 700 }}>{clip.downloads}</td>
                     <td
                       style={{
                         padding: "14px 0",

--- a/frontend/lib/generation-settings.ts
+++ b/frontend/lib/generation-settings.ts
@@ -15,7 +15,7 @@ export const GENERATION_SETTINGS_STORAGE_KEY = "insightclips-generation-settings
 
 export const CLIP_DURATION_OPTIONS = [15, 30, 45, 60] as const;
 export const CLIP_COUNT_OPTIONS = [2, 3, 4, 5, 6] as const;
-export const MAX_TOPIC_FOCUS_LENGTH = 120;
+export const MAX_TOPIC_LENGTH = 500;
 
 type GenerationTemplateDefinition = {
   id: GenerationTemplateId;
@@ -38,7 +38,7 @@ export const GENERATION_TEMPLATES: GenerationTemplateDefinition[] = [
     generationSettings: {
       clip_duration_seconds: 30,
       number_of_clips: 4,
-      topic_focus: "Prioritize strong opening hooks and clear payoff lines.",
+      topic_focus: "",
       subtitles_enabled: true,
     },
     exportMode: "portrait",
@@ -46,7 +46,7 @@ export const GENERATION_TEMPLATES: GenerationTemplateDefinition[] = [
       ...buildSubtitleStyleFromPreset("bold"),
       font_family: "DM Sans",
       font_size: 26,
-      position: "center",
+      position: "bottom",
     },
   },
   {
@@ -58,7 +58,7 @@ export const GENERATION_TEMPLATES: GenerationTemplateDefinition[] = [
     generationSettings: {
       clip_duration_seconds: 45,
       number_of_clips: 3,
-      topic_focus: "Keep setup and payoff together so each clip feels complete.",
+      topic_focus: "",
       subtitles_enabled: true,
     },
     exportMode: "portrait",
@@ -78,7 +78,7 @@ export const GENERATION_TEMPLATES: GenerationTemplateDefinition[] = [
     generationSettings: {
       clip_duration_seconds: 20,
       number_of_clips: 5,
-      topic_focus: "Surface concise expert takeaways and memorable one-liners.",
+      topic_focus: "",
       subtitles_enabled: true,
     },
     exportMode: "landscape",
@@ -106,8 +106,7 @@ export function normalizeGenerationSettings(
   const fallback = buildDefaultGenerationSettings();
   const clipDuration = Number(settings?.clip_duration_seconds);
   const numberOfClips = Number(settings?.number_of_clips);
-  const topicFocus = typeof settings?.topic_focus === "string" ? settings.topic_focus : "";
-
+  const projectPrompt = typeof settings?.topic_focus === "string" ? settings.topic_focus : "";
   return {
     clip_duration_seconds: CLIP_DURATION_OPTIONS.includes(clipDuration as (typeof CLIP_DURATION_OPTIONS)[number])
       ? clipDuration
@@ -115,7 +114,7 @@ export function normalizeGenerationSettings(
     number_of_clips: CLIP_COUNT_OPTIONS.includes(numberOfClips as (typeof CLIP_COUNT_OPTIONS)[number])
       ? numberOfClips
       : fallback.number_of_clips,
-    topic_focus: topicFocus.trim().slice(0, MAX_TOPIC_FOCUS_LENGTH),
+    topic_focus: projectPrompt.trim().slice(0, MAX_TOPIC_LENGTH),
     subtitles_enabled:
       typeof settings?.subtitles_enabled === "boolean"
         ? settings.subtitles_enabled


### PR DESCRIPTION
This PR improves the clip generation workflow and related UI behavior.

What changed:
- clarified how topic_focus is used as a clip-selection hint
- normalized generation settings before sending them to the backend
- updated clip rendering behavior for different visual output modes
- polished related frontend pages and shared UI components
- adjusted tests for the updated generation flow

Notes:
- topic_focus is used to guide segment selection, not to generate video from scratch
- generated clips still come from the original podcast video via ffmpeg